### PR TITLE
Changine default pullPolicy and probe timeouts

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -13,8 +13,10 @@ name: ping-devops
 # 0.2.4 - Turn off vault for ldap-sdk-tools
 # 0.2.5 - Add ability to use external images (GDO-590, helm-charts/issues/10)
 # 0.2.6 - Fix a regression with the clusterIdentifier on depoyments/statefulsets
+# 0.2.7 - Changing default pullPolicy to Always.  Helps when using changing edge tag
+#         Increasing liveness/readiness probe timeoutSeconds to 5 as 1 is often to short
 ########################################################################
-version: 0.2.6
+version: 0.2.7
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -72,8 +72,7 @@ global:
     repository: pingidentity
     name:
     tag: 2010
-    pullPolicy: IfNotPresent
-    # used by images to perform curl commands
+    pullPolicy: Always
 
   ############################################################
   # External Images
@@ -142,6 +141,8 @@ global:
   #
   # Indicates several general container variables to control
   # how the container is run, scheduled, placed
+  #
+  # https://kubernetes.io/docs/concepts/workloads/controllers/
   ############################################################
   container:
     replicaCount: 1
@@ -160,46 +161,23 @@ global:
   # Probes
   #
   # Probes have a number of fields that you can use to more precisely control the
-  # behavior of liveness and readiness checks:
+  # behavior of liveness and readiness checks.
   #
-  #  initialDelaySeconds: Number of seconds after the container has started before
-  #                       liveness or readiness probes are initiated.
-  #                           Defaults to 0 seconds.
-  #                           Minimum value is 0.
-  #
-  #        periodSeconds: How often (in seconds) to perform the probe.
-  #                           Default to 10 seconds.
-  #                           Minimum value is 1.
-  #
-  #       timeoutSeconds: Number of seconds after which the probe times out.
-  #                           Defaults to 1 second.
-  #                           Minimum value is 1.
-  #
-  #     successThreshold: Minimum consecutive successes for the probe to be considered
-  #                       successful after having failed.
-  #                           Defaults to 1. Must be 1 for liveness.
-  #                           Minimum value is 1.
-  #
-  #     failureThreshold: When a probe fails, Kubernetes will try failureThreshold times
-  #                       before giving up. Giving up in case of liveness probe means
-  #                       restarting the container. In case of readiness probe the
-  #                       Pod will be marked Unready.
-  #                           Defaults to 3.
-  #                           Minimum value is 1.
+  # https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
   ############################################################
   probes:
     liveness:
       command: /opt/liveness.sh
       initialDelaySeconds: 30
       periodSeconds: 30
-      timeoutSeconds: 1
+      timeoutSeconds: 5
       successThreshold: 1
       failureThreshold: 4
     readiness:
       command: /opt/liveness.sh
       initialDelaySeconds: 30
       periodSeconds: 30
-      timeoutSeconds: 1
+      timeoutSeconds: 5
       successThreshold: 1
       failureThreshold: 4
 

--- a/docs/config/image.md
+++ b/docs/config/image.md
@@ -9,12 +9,12 @@ The example found in the `global:` section is:
     repository: pingidentity
     name:                                 # Should be completed in product section
     tag: 2010
-    pullPolicy: IfNotPresent
+    pullPolicy: Always
 ```
 
 Translating to kubernetes manifest information:
 
 ```yaml
     image: pingidentity/pingaccess:2010   # Example if image.name=pingaccess
-    imagePullPolicy: IfNotPresent
+    imagePullPolicy: Always
 ```

--- a/docs/config/probes.md
+++ b/docs/config/probes.md
@@ -13,14 +13,14 @@ global:
       command: /opt/liveness.sh
       initialDelaySeconds: 30
       periodSeconds: 30
-      timeoutSeconds: 1
+      timeoutSeconds: 5
       successThreshold: 1
       failureThreshold: 4
     readiness:
       command: /opt/liveness.sh
       initialDelaySeconds: 30
       periodSeconds: 30
-      timeoutSeconds: 1
+      timeoutSeconds: 5
       successThreshold: 1
       failureThreshold: 4
 ```


### PR DESCRIPTION
* Changing default pullPolicy to Always.  Helps when using changing edge tag
* Increasing liveness/readiness probe timeoutSeconds to 5 as 1 is often to short