### PR TITLE
v0.2.9 - provide proper service names to PRIVATE_HOSTNAMES in global-env-vars configmap

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -17,7 +17,7 @@ name: ping-devops
 #         Increasing liveness/readiness probe timeoutSeconds to 5 as 1 is often to short
 # 0.2.8 - Create release env-vars congigmap.  Provides each products PRIVATE_HOSTNAME
 ########################################################################
-version: 0.2.7
+version: 0.2.8
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/

--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -15,6 +15,7 @@ name: ping-devops
 # 0.2.6 - Fix a regression with the clusterIdentifier on depoyments/statefulsets
 # 0.2.7 - Changing default pullPolicy to Always.  Helps when using changing edge tag
 #         Increasing liveness/readiness probe timeoutSeconds to 5 as 1 is often to short
+# 0.2.8 - Create release env-vars congigmap.  Provides each products PRIVATE_HOSTNAME
 ########################################################################
 version: 0.2.7
 description: All Ping Identity product images with integration

--- a/charts/ping-devops/templates/global/configmap.yaml
+++ b/charts/ping-devops/templates/global/configmap.yaml
@@ -1,0 +1,20 @@
+{{- include "pinglib.configmap" (list . "global") -}}
+
+
+
+{{- define "global.configmap" -}}
+{{- $top := index . 0 -}}
+{{- $v := index . 1 -}}
+data:
+  {{/* Remove the pingaccess when we move to an engine/admin */}}
+  {{ if (index $top.Values "pingaccess").enabled }}PA_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingaccess").name) | quote }}{{ end }}
+  {{ if (index $top.Values "pingaccess-engine").enabled }}PA_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingaccess-engine").name) | quote }}{{ end }}
+  {{ if (index $top.Values "pingaccess-admin").enabled }}PA_ADMIN_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingaccess-admin").name) | quote }}{{ end }}
+  {{ if (index $top.Values "pingdatasync").enabled }}PDS_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingdatasync").name) | quote }}{{ end }}
+  {{ if (index $top.Values "pingdatagovernance").enabled }}PDG_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingdatagovernance").name) | quote }}{{ end }}
+  {{ if (index $top.Values "pingdatagovernancepap").enabled }}PDGP_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingdatagovernancepap").name) | quote }}{{ end }}
+  {{ if (index $top.Values "pingdirectory").enabled }}PD_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingdirectory").name) | quote }}{{ end }}
+  {{ if (index $top.Values "pingdirectoryproxy").enabled }}PDP_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingdirectoryproxy").name) | quote }}{{ end }}
+  {{ if (index $top.Values "pingfederate-engine").enabled }}PF_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingfederate-engine").name) | quote }}{{ end }}
+  {{ if (index $top.Values "pingfederate-admin").enabled }}PF_ADMIN_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingfederate-admin").name) | quote }}{{ end }}
+{{- end -}}

--- a/charts/ping-devops/templates/pinglib/_deployment.yaml
+++ b/charts/ping-devops/templates/pinglib/_deployment.yaml
@@ -20,7 +20,8 @@ spec:
         clusterIdentifier: {{ include "pinglib.fullimagename" . }}
         {{- include "pinglib.selector.labels" . | nindent 8 }}
       annotations: {{ include "pinglib.annotations.vault" $v.vault | nindent 8 }}
-        checksum/config: {{ include (print $top.Template.BasePath "/" $v.name "/configmap.yaml") $top | sha256sum }}
+        {{/* Following checksum pulls in release and product configmaps and creates checksum to force restart  */}}
+        checksum/config: {{ printf "%s%s" (include (print $top.Template.BasePath "/global/configmap.yaml") $top) (include (print $top.Template.BasePath "/" $v.name "/configmap.yaml") $top) | sha256sum }}
     spec:
       {{- if $v.vault.enabled }}
       serviceAccountName: vault-auth

--- a/charts/ping-devops/templates/pinglib/_helpers.tpl
+++ b/charts/ping-devops/templates/pinglib/_helpers.tpl
@@ -4,7 +4,7 @@ Expand the name of the chart.
 {{- define "pinglib.name" -}}
 {{- $top := index . 0 -}}
 {{- $v := index . 1 -}}
-{{- default $v.name | trunc 63 | trimSuffix "-" -}}
+{{- default "global" $v.name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/**********************************************************************
@@ -15,7 +15,7 @@ If release name contains chart name it will be used as a full name.
 {{- define "pinglib.fullname" -}}
 {{- $top := index . 0 -}}
 {{- $v := index . 1 -}}
-    {{- include "pinglib.addreleasename" (append . $v.name) -}}
+    {{- include "pinglib.addreleasename" (append . (default "global" $v.name)) -}}
 {{- end -}}
 
 {{/**********************************************************************

--- a/charts/ping-devops/templates/pinglib/_merge-util.yaml
+++ b/charts/ping-devops/templates/pinglib/_merge-util.yaml
@@ -15,7 +15,7 @@ These will create
     {{- $resourceType := index . 2 -}}
 
     {{- $mergedValues := merge (index $top.Values $prodName) $top.Values.global -}}
-    {{- if $mergedValues.enabled -}}
+    {{- if or $mergedValues.enabled (eq $prodName "global") -}}
         {{- $paramList := list $top $mergedValues -}}
 
         {{- $overrideTemplate := printf "%s.%s" $prodName $resourceType -}}

--- a/charts/ping-devops/templates/pinglib/_statefulset.yaml
+++ b/charts/ping-devops/templates/pinglib/_statefulset.yaml
@@ -19,8 +19,8 @@ spec:
     metadata: {{ include "pinglib.metadata.labels" .  | nindent 6  }}
         {{ include "pinglib.selector.labels" . | nindent 8 }}
       annotations: {{ include "pinglib.annotations.vault" $v.vault | nindent 8 }}
-        checksum/config: {{ include (print $top.Template.BasePath "/" $v.name "/configmap.yaml") $top | sha256sum }}
-
+        {{/* Following checksum pulls in release and product configmaps and creates checksum to force restart  */}}
+        checksum/config: {{ printf "%s%s" (include (print $top.Template.BasePath "/global/configmap.yaml") $top) (include (print $top.Template.BasePath "/" $v.name "/configmap.yaml") $top) | sha256sum }}
     spec:
       terminationGracePeriodSeconds: 300
       {{- if $v.vault.enabled }}

--- a/charts/ping-devops/templates/pinglib/_yamlSnippets.tpl
+++ b/charts/ping-devops/templates/pinglib/_yamlSnippets.tpl
@@ -23,7 +23,7 @@ envFrom:
 - configMapRef:
     name: {{ include "pinglib.fullname" . }}-env-vars
 - configMapRef:
-    name: {{ $top.Release.Name }}-env-vars
+    name: {{ $top.Release.Name }}-global-env-vars
     optional: true
 - secretRef:
     name: {{ $v.license.secret.devOps }}

--- a/docs/examples/everything.md
+++ b/docs/examples/everything.md
@@ -42,9 +42,15 @@ pingdirectory:
 
 pingfederate-admin:
   enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: baseline/pingfederate
 
 pingfederate-engine:
   enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: baseline/pingfederate
 
 ldap-sdk-tools:
   enabled: false

--- a/docs/examples/everything.yaml
+++ b/docs/examples/everything.yaml
@@ -28,9 +28,15 @@ pingdirectory:
 
 pingfederate-admin:
   enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: baseline/pingfederate
 
 pingfederate-engine:
   enabled: true
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: baseline/pingfederate
 
 ldap-sdk-tools:
   enabled: false

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,13 +12,13 @@ Helm is a package deployment tool for Kubernetes. It can be used with PingDevops
 
 The charts use a secret called `devops-secret` to obtain an evaluation license for running images.
 
-   * Eval License - Use your `PING_IDENTITY_DEVOPS_USER/PING_IDENTITY_DEVOPS_KEY` credentials
-   along with your `PING_IDENTITY_ACCEPT_EULA` setting.
-     * For more information on obtaining credentials click [here](https://pingidentity-devops.gitbook.io/devops/getstarted/prod-license#obtaining-a-ping-identity-devops-user-and-key).
-     * For more infomration on using `ping-devops` utility click [here](https://pingidentity-devops.gitbook.io/devops/devopsutils/pingdevopsutil).
+* Eval License - Use your `PING_IDENTITY_DEVOPS_USER/PING_IDENTITY_DEVOPS_KEY` credentials
+  along with your `PING_IDENTITY_ACCEPT_EULA` setting.
+  * For more information on obtaining credentials click [here](https://pingidentity-devops.gitbook.io/devops/getstarted/prod-license#obtaining-a-ping-identity-devops-user-and-key).
+  * For more infomration on using `ping-devops` utility click [here](https://pingidentity-devops.gitbook.io/devops/devopsutils/pingdevopsutil).
 
         ```shell
-        ping-devops generate devops-secret | kubectl -apply -f -
+        ping-devops generate devops-secret | kubectl apply -f -
         ```
 
 ## Install Helm 3
@@ -27,9 +27,9 @@ Ensure that you have Helm 3 installed.
 
 * Installing on MacOS (or linux with brew)
 
-    ```shell
-    brew install helm
-    ```
+```shell
+brew install helm
+```
 
 * Installing on other OS - <https://helm.sh/docs/intro/install/>
 
@@ -53,8 +53,7 @@ helm repo update
 
 ## Install the Ping DevOps Chart
 
-Install `the ping-devops` chart using the `helm install {release} {chart} ...` using the example
-below.  In this case, it is installing a release called `pf`:
+Install the `ping-devops` chart using the example below.  In this case, it is installing a release called `pf`:
 
 * PingFederate Admin instance
 * PingFederate Engine instance


### PR DESCRIPTION
This change will create a configmap `{release-name}-global-env-vars` which will be pulled in optionally by all deployments/statefulsets, if that product is enabled.  As an example, it will create the following:

```
apiVersion: v1
kind: ConfigMap
data:
  PA_ENGINE_PRIVATE_HOSTNAME: demo-pingaccess
  PD_ENGINE_PRIVATE_HOSTNAME: demo-pingdirectory
  PDG_ENGINE_PRIVATE_HOSTNAME: demo-pingdatagovernance
  PDS_ENGINE_PRIVATE_HOSTNAME: demo-pingdatasync
  PF_ADMIN_PRIVATE_HOSTNAME: demo-pingfederate-admin
  PF_ENGINE_PRIVATE_HOSTNAME: demo-pingfederate-engine
```

This will be key in supporting our server-profiles, so that integration will operate correctly between products.

> For Example: pingfederate will be able to properly talk to the pingdirectory instance using the correct service name.

> Note: We may need to add the -cluster to these names if a headless service connection is needed, but so far between PF/PD, that's not the case.

> **Possible Breaking Change**: If using the original {release-name}-env-vars, that will go away, but we weren't creating this by default.