### PR TITLE
Rel0.3.2

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -22,8 +22,9 @@ name: ping-devops
 #         workload.statefulSet values.
 # 0.3.1 - Add back {release}-env-vars configmap ref back as well as supporting
 #         container.envFrom values
+# 0.3.2 - Refer to http://localhost:8000/release-notes/#release-032
 ########################################################################
-version: 0.3.1
+version: 0.3.2
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/

--- a/charts/ping-devops/templates/global/configmap.yaml
+++ b/charts/ping-devops/templates/global/configmap.yaml
@@ -7,14 +7,55 @@
 {{- $v := index . 1 -}}
 data:
   {{/* Remove the pingaccess when we move to an engine/admin */}}
-  {{ if (index $top.Values "pingaccess").enabled }}PA_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingaccess").name) | quote }}{{ end }}
-  {{ if (index $top.Values "pingaccess-engine").enabled }}PA_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingaccess-engine").name) | quote }}{{ end }}
-  {{ if (index $top.Values "pingaccess-admin").enabled }}PA_ADMIN_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingaccess-admin").name) | quote }}{{ end }}
-  {{ if (index $top.Values "pingdatasync").enabled }}PDS_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingdatasync").name) | quote }}{{ end }}
-  {{ if (index $top.Values "pingdatagovernance").enabled }}PDG_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingdatagovernance").name) | quote }}{{ end }}
-  {{ if (index $top.Values "pingdatagovernancepap").enabled }}PDGP_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingdatagovernancepap").name) | quote }}{{ end }}
-  {{ if (index $top.Values "pingdirectory").enabled }}PD_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingdirectory").name) | quote }}{{ end }}
-  {{ if (index $top.Values "pingdirectoryproxy").enabled }}PDP_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingdirectoryproxy").name) | quote }}{{ end }}
-  {{ if (index $top.Values "pingfederate-engine").enabled }}PF_ENGINE_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingfederate-engine").name) | quote }}{{ end }}
-  {{ if (index $top.Values "pingfederate-admin").enabled }}PF_ADMIN_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (append . (index $top.Values "pingfederate-admin").name) | quote }}{{ end }}
+  {{ include "global.configmap.env.hostname" (list $top $v "PA_ENGINE_PRIVATE_HOSTNAME" "pingaccess") }}
+  {{ include "global.configmap.env.hostname" (list $top $v "PA_ENGINE_PRIVATE_HOSTNAME" "pingaccess-engine") }}
+  {{ include "global.configmap.env.hostname" (list $top $v "PA_ADMIN_PRIVATE_HOSTNAME" "pingaccess-admin") }}
+  {{ include "global.configmap.env.hostname" (list $top $v "PDS_ENGINE_PRIVATE_HOSTNAME" "pingdatasync") }}
+  {{ include "global.configmap.env.hostname" (list $top $v "PDG_ENGINE_PRIVATE_HOSTNAME" "pingdatagovernance") }}
+  {{ include "global.configmap.env.hostname" (list $top $v "PDGP_ENGINE_PRIVATE_HOSTNAME" "pingdatagovernancepap") }}
+  {{ include "global.configmap.env.hostname" (list $top $v "PD_DELEGATOR_PRIVATE_HOSTNAME" "pingdelegator") }}
+  {{ include "global.configmap.env.hostname" (list $top $v "PD_ENGINE_PRIVATE_HOSTNAME" "pingdirectory") }}
+  {{ include "global.configmap.env.hostname" (list $top $v "PDP_ENGINE_PRIVATE_HOSTNAME" "pingdirectoryproxy") }}
+  {{ include "global.configmap.env.hostname" (list $top $v "PF_ENGINE_PRIVATE_HOSTNAME" "pingfederate-engine") }}
+  {{ include "global.configmap.env.hostname" (list $top $v "PF_ADMIN_PRIVATE_HOSTNAME" "pingfederate-admin") }}
+
+  {{/* Remove the pingaccess when we move to an engine/admin */}}
+  {{ include "global.configmap.env.ingress.hostname" (list $top $v "PA_ENGINE_PUBLIC_HOSTNAME" "pingaccess") }}
+  {{ include "global.configmap.env.ingress.hostname" (list $top $v "PA_ENGINE_PUBLIC_HOSTNAME" "pingaccess-engine") }}
+  {{ include "global.configmap.env.ingress.hostname" (list $top $v "PA_ADMIN_PUBLIC_HOSTNAME" "pingaccess-admin") }}
+  {{ include "global.configmap.env.ingress.hostname" (list $top $v "PDS_ENGINE_PUBLIC_HOSTNAME" "pingdatasync") }}
+  {{ include "global.configmap.env.ingress.hostname" (list $top $v "PDG_ENGINE_PUBLIC_HOSTNAME" "pingdatagovernance") }}
+  {{ include "global.configmap.env.ingress.hostname" (list $top $v "PDGP_ENGINE_PUBLIC_HOSTNAME" "pingdatagovernancepap") }}
+  {{ include "global.configmap.env.ingress.hostname" (list $top $v "PD_DELEGATOR_PUBLIC_HOSTNAME" "pingdelegator") }}
+  {{ include "global.configmap.env.ingress.hostname" (list $top $v "PD_ENGINE_PUBLIC_HOSTNAME" "pingdirectory") }}
+  {{ include "global.configmap.env.ingress.hostname" (list $top $v "PDP_ENGINE_PUBLIC_HOSTNAME" "pingdirectoryproxy") }}
+  {{ include "global.configmap.env.ingress.hostname" (list $top $v "PF_ENGINE_PUBLIC_HOSTNAME" "pingfederate-engine") }}
+  {{ include "global.configmap.env.ingress.hostname" (list $top $v "PF_ADMIN_PUBLIC_HOSTNAME" "pingfederate-admin") }}
+{{- end -}}
+
+
+{{- define "global.configmap.env.hostname" -}}
+{{- $top := index . 0 }}
+{{- $v := index . 1 }}
+{{- $envName := index . 2 }}
+{{- $prodName := index . 3 }}
+{{- with (index $top.Values $prodName) }}
+{{- if .enabled }}
+  {{ $envName }}: {{ include "pinglib.addreleasename" (list $top $v .name) | quote }}
+{{- end }}
+{{- end }}
+{{- end -}}
+
+{{- define "global.configmap.env.ingress.hostname" -}}
+{{- $top := index . 0 }}
+{{- $v := index . 1 }}
+{{- $envName := index . 2 }}
+{{- $prodName := index . 3 }}
+{{- with (index $top.Values $prodName) }}
+{{- if and .enabled .ingress.enabled }}
+{{- range .ingress.hosts }}
+  {{ $envName }}: {{ include "pinglib.ingress.hostname" (list $top $v .host) | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end -}}

--- a/charts/ping-devops/templates/pingdelegator/configmap.yaml
+++ b/charts/ping-devops/templates/pingdelegator/configmap.yaml
@@ -6,10 +6,9 @@
 {{- $top := index . 0 -}}
 {{- $v := index . 1 -}}
 data:
-  PD_DELEGATOR_PUBLIC_HOSTNAME: {{ $v.publicHostname | quote  }}
-  PF_ENGINE_PUBLIC_HOSTNAME: {{ $v.tokenProvider.hostname | quote  }}
-  PF_ENGINE_PUBLIC_PORT: {{ $v.tokenProvider.port | quote  }}
+  {{/* ISSUE when set to 443, due to fact that delegator cannot open port 443 --> PD_DELEGATOR_HTTPS_PORT: {{ $v.publicPort | quote  }} */}}
+  PD_DELEGATOR_PUBLIC_PORT: {{ $v.publicPort | quote  }}
+  PD_ENGINE_PUBLIC_PORT: {{ $v.pingDirectoryServer.port | quote }}
+  PF_ENGINE_PUBLIC_PORT: {{ $v.tokenProvider.port | quote }}
   PF_DELEGATOR_CLIENTID: {{ $v.tokenProvider.clientId | quote  }}
-  PD_ENGINE_PRIVATE_HOSTNAME: {{ $v.pingDirectoryServer.hostname | quote  }}
-  PD_ENGINE_PRIVATE_PORT: {{ $v.pingDirectoryServer.port | quote  }}
 {{- end -}}

--- a/charts/ping-devops/templates/pingfederate-engine/workload.yaml
+++ b/charts/ping-devops/templates/pingfederate-engine/workload.yaml
@@ -4,6 +4,7 @@
 {{- define "pingfederate-engine.workload" -}}
 {{- $top := index . 0 -}}
 {{- $v := index . 1 -}}
+{{- $adminServer := printf "%s:%s" (include "pinglib.fullname" . | replace "-engine" "-admin" ) (default 9999 $v.envs.PF_ADMIN_PORT) -}}
 spec:
   template:
     metadata:
@@ -11,8 +12,26 @@ spec:
         clusterIdentifier: {{ include "pinglib.fullimagename" . }}
     spec:
       initContainers:
-      - name: init
-        image: {{ $v.externalImage.curl }}
-        command: ['sh', '-c', 'until curl --connect-timeout 1 --silent -k https://{{ include "pinglib.fullname" . | replace "-engine" "-admin" }}:{{ $v.envs.PF_ADMIN_PORT }}/pingfederate/app ; do echo waiting for https://{{ include "pinglib.fullname" . | replace "-engine" "-admin" }}:{{ $v.envs.PF_ADMIN_PORT }}/pingfederate/app ; sleep 2 ; done']
-
+      - name: wait-for-admin-init
+        imagePullPolicy: {{ $v.image.pullPolicy }}
+        image: {{ $v.externalImage.pingtoolkit }}
+        command: ['sh', '-c', 'echo "Waiting for {{ $adminServer }}..." && wait-for {{ $adminServer }} -- echo "{{ $adminServer }} running"']
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 250m
+            memory: 64Mi
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+          readOnlyRootFilesystem: true
+          runAsGroup: 1000
+          runAsNonRoot: true
+          runAsUser: 100
 {{- end -}}
+
+

--- a/charts/ping-devops/templates/pinglib/_ingress.tpl
+++ b/charts/ping-devops/templates/pinglib/_ingress.tpl
@@ -15,32 +15,14 @@ spec:
   {{- range $v.ingress.tls }}
   - hosts:
     {{- range .hosts }}
-    {{- if contains "._defaultDomain_" . }}
-    {{- $rawHost := . | replace "._defaultDomain_" "" }}
-    - {{ include "pinglib.ingress.gethostprepend" $ }}
-      {{- $rawHost}}
-      {{- include "pinglib.ingress.gethostappend" $ -}}
-      {{- include "pinglib.ingress.gethostsubdomain" $ -}}
-      .{{ $defaultDomain }}
-    {{- else }}
-    - {{ . | quote }}
-    {{- end }}
+    - {{ include "pinglib.ingress.hostname" (list $top $v .) | quote }}
     {{- end }}
     secretName: {{ .secretName | replace "_defaultTlsSecret_" (default "" $defaultTlsSecret) | quote }}
   {{- end }}
   {{- end }}
   rules:
   {{- range $v.ingress.hosts }}
-    {{- if contains "._defaultDomain_" .host }}
-    {{- $rawHost := .host | replace "._defaultDomain_" "" }}
-    - host: {{ include "pinglib.ingress.gethostprepend" $ }}
-      {{- $rawHost}}
-      {{- include "pinglib.ingress.gethostappend" $ -}}
-      {{- include "pinglib.ingress.gethostsubdomain" $ -}}
-      .{{ $defaultDomain }}
-    {{- else }}
-    - host: {{ . | quote }}
-    {{- end }}
+    - host: {{ include "pinglib.ingress.hostname" (list $top $v .host) | quote  }}
       http:
         paths:
         {{- range .paths }}
@@ -58,7 +40,37 @@ spec:
 {{- end -}}
 
 
+{{/**********************************************************************
+   ** pinglib.ingress.hostname
+   **
+   ** Returns an ingress hostname honoring the release-name and
+   ** _defaultDomain_ flag.
+   **********************************************************************/}}
+{{- define "pinglib.ingress.hostname" -}}
+{{- $top := index . 0 -}}
+{{- $v := index . 1 -}}
+{{- $rawHost := index . 2 -}}
 
+{{- $fullName := include "pinglib.fullname" (list $top $v) -}}
+{{- $defaultDomain := $v.ingress.defaultDomain -}}
+{{- if contains "._defaultDomain_" $rawHost }}
+  {{- $newHost := $rawHost | replace "._defaultDomain_" "" }}
+  {{- include "pinglib.ingress.gethostprepend" $ -}}
+  {{- $newHost -}}
+  {{- include "pinglib.ingress.gethostappend" $ -}}
+  {{- include "pinglib.ingress.gethostsubdomain" $ -}}
+  .{{ $defaultDomain }}
+{{- else }}
+  {{- $rawHost }}
+{{- end }}
+{{- end }}
+
+
+{{/**********************************************************************
+   ** pinglib.ingress.gethostprepend
+   **
+   ** Prepends the release-name to the host if enabled
+   **********************************************************************/}}
 {{- define "pinglib.ingress.gethostprepend" -}}
 {{- $top := index . 0 -}}
 {{- $v := index . 1 -}}
@@ -67,6 +79,11 @@ spec:
   {{- end }}
 {{- end -}}
 
+{{/**********************************************************************
+   ** pinglib.ingress.gethostappend
+   **
+   ** Appends the release-name to the host if enabled
+   **********************************************************************/}}
 {{- define "pinglib.ingress.gethostappend" -}}
 {{- $top := index . 0 -}}
 {{- $v := index . 1 -}}
@@ -75,6 +92,11 @@ spec:
   {{- end }}
 {{- end -}}
 
+{{/**********************************************************************
+   ** pinglib.ingress.gethostsubdomain
+   **
+   ** Adds the release-name to the subdomain host if enabled
+   **********************************************************************/}}
 {{- define "pinglib.ingress.gethostsubdomain" -}}
 {{- $top := index . 0 -}}
 {{- $v := index . 1 -}}

--- a/charts/ping-devops/templates/pinglib/_yamlSnippets.tpl
+++ b/charts/ping-devops/templates/pinglib/_yamlSnippets.tpl
@@ -85,6 +85,7 @@ app.kubernetes.io/instance: {{ $top.Release.Name }}
 #
 vault.hashicorp.com/agent-pre-populate-only: {{ ( index . "pre-populate-only" ) | quote }}
 vault.hashicorp.com/agent-inject: "true"
+vault.hashicorp.com/agent-init-first: "true"
 vault.hashicorp.com/role: {{ ( index . "role" ) | quote }}
 vault.hashicorp.com/log-level:  {{ ( index . "log-level" ) | quote }}
 vault.hashicorp.com/preserve-secret-case:  {{ ( index . "preserve-secret-case" ) | quote }}

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -36,9 +36,11 @@ global:
     addReleaseNameToHost: subdomain
     defaultDomain: example.com
     defaultTlsSecret:
-    annotations:
-      nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-      kubernetes.io/ingress.class: "nginx-public"
+    annotations: {}
+      # nginx example
+      # nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+      # kubernetes.io/ingress.class: "nginx-public"
+
   ############################################################
   # Fields used to annotate secret hashicorp vault information
   #
@@ -83,6 +85,8 @@ global:
   ############################################################
   externalImage:
     curl: curlimages/curl:latest
+    # pingtoolkit - based on alpine
+    pingtoolkit: pingidentity/pingtoolkit:latest
 
   ############################################################
   # Services
@@ -453,15 +457,13 @@ pingdelegator:
   image:
     name: pingdelegator
 
-  publicHostname: localhost
+  publicPort: 443
 
   tokenProvider:
-    hostname: localhost
-    port: 443
+    port: 9031
     clientId: dadmin
 
   pingDirectoryServer:
-    hostname: pingdirectory
     port: 443
 
   envs:

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -84,7 +84,6 @@ global:
   # such as using curl.
   ############################################################
   externalImage:
-    curl: curlimages/curl:latest
     # pingtoolkit - based on alpine
     pingtoolkit: pingidentity/pingtoolkit:latest
 

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -283,7 +283,6 @@ pingfederate-admin:
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
     SERVER_PROFILE_PATH: getting-started/pingfederate
-    SERVER_PROFILE_BRANCH: master
 
   services:
     admin:
@@ -324,7 +323,6 @@ pingfederate-engine:
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
     SERVER_PROFILE_PATH: getting-started/pingfederate
-    SERVER_PROFILE_BRANCH: master
     PF_ADMIN_PORT: "9999"
 
   clustering:
@@ -408,7 +406,6 @@ pingdirectory:
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
     SERVER_PROFILE_PATH: baseline/pingdirectory
-    SERVER_PROFILE_BRANCH: master
     MAKELDIF_USERS: "20000"
 
   services:
@@ -469,7 +466,6 @@ pingdelegator:
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
     SERVER_PROFILE_PATH: baseline/pingdelegator
-    SERVER_PROFILE_BRANCH: master
 
   services:
     https:
@@ -501,7 +497,6 @@ pingdatasync:
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
     SERVER_PROFILE_PATH: simple-sync/pingdatasync
-    SERVER_PROFILE_BRANCH: master
 
   services:
     ldaps:
@@ -525,7 +520,6 @@ pingdatagovernance:
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
     SERVER_PROFILE_PATH: baseline/pingdatagovernance-8.1.0.0
-    SERVER_PROFILE_BRANCH: master
 
   services:
     https:
@@ -561,7 +555,6 @@ pingaccess:
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
     SERVER_PROFILE_PATH: getting-started/pingaccess
-    SERVER_PROFILE_BRANCH: master
 
   services:
     admin:
@@ -613,7 +606,6 @@ pingdataconsole:
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
     SERVER_PROFILE_PATH: baseline/pingdataconsole
-    SERVER_PROFILE_BRANCH: master
 
   services:
     https:
@@ -645,6 +637,5 @@ pd-replication-timing:
   envs:
     SERVER_PROFILE_URL: https://www.github.com/pingidentity/pingidentity-server-profiles
     SERVER_PROFILE_PATH: dsreplication-timing
-    SERVER_PROFILE_BRANCH: master
     STARTUP_COMMAND: /opt/out/instance/bin/start-server
     STARTUP_BACKGROUND_OPTS: ""

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -2,11 +2,14 @@
 
 ## Release 0.3.2
 
+* Replaced init container on pingfederate-engine to use pingtoolkit rather than 3rd party
+  curlimage.  Addtionally added resource constraints and security context to this init
+  container.
 * Remove hardcoded SERVER_PROFILE_BRANCH set to master, relying on git repo default branch
 * Cleanup pingdelegator values.  public hostnames for pingfederate and pingdirectory
   built based off of ingress hostnames, part of `{release-name}-blobal-env-vars` configmap.
 * Remove default nginx annotations of ingress resources.  If an nginx controller is used
-  for ingress, the folloing ingress annotations should be included:
+  for ingress, the following ingress annotations should be included:
 
     !!! warning
     By removing the following annotations from the default, use of current config values

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,3 +1,25 @@
+# Release Notes
+
+## Release 0.3.2
+
+* Remove hardcoded SERVER_PROFILE_BRANCH set to master, relying on git repo default branch
+* Cleanup pingdelegator values.  public hostnames for pingfederate and pingdirectory
+  built based off of ingress hostnames, part of `{release-name}-blobal-env-vars` configmap.
+* Remove default nginx annotations of ingress resources.  If an nginx controller is used
+  for ingress, the folloing ingress annotations should be included:
+
+    !!! warning
+    By removing the following annotations from the default, use of current config values
+    will result in no ingress being set.  You must add these in via your .yaml file or via
+    seperate --set settings.
+
+```yaml
+global:
+ annotations:
+   nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+   kubernetes.io/ingress.class: "nginx-public"
+```
+
 ## Release 0.3.1
 
 * Add container envFrom for `{release-name}-env-vars` back as optional.


### PR DESCRIPTION
* Replaced init container on pingfederate-engine to use pingtoolkit rather than 3rd party
  curlimage.  Addtionally added resource constraints and security context to this init
  container. Resolves #30 and partial #28
* Remove hardcoded SERVER_PROFILE_BRANCH set to master, relying on git repo default branch. Resolves #33
* Cleanup pingdelegator values.  public hostnames for pingfederate and pingdirectory
  built based off of ingress hostnames, part of `{release-name}-blobal-env-vars` configmap.
* Remove default nginx annotations of ingress resources.  If an nginx controller is used
  for ingress (Res;ves #31), the following ingress annotations should be included:

    !!! warning
    By removing the following annotations from the default, use of current config values
    will result in no ingress being set.  You must add these in via your .yaml file or via
    seperate --set settings.

```yaml
global:
 annotations:
   nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
   kubernetes.io/ingress.class: "nginx-public"
```