### PR TITLE
Release 0.4.3

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -7,8 +7,9 @@ name: ping-devops
 # 0.4.0 - Refer to http://helm.pingidentity.com/release-notes/#release-040
 # 0.4.1 - Refer to http://helm.pingidentity.com/release-notes/#release-041
 # 0.4.2 - Refer to http://helm.pingidentity.com/release-notes/#release-042
+# 0.4.3 - Refer to http://helm.pingidentity.com/release-notes/#release-043
 ########################################################################
-version: 0.4.2
+version: 0.4.3
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/

--- a/charts/ping-devops/templates/pingdirectory/service-cluster.yaml
+++ b/charts/ping-devops/templates/pingdirectory/service-cluster.yaml
@@ -4,11 +4,9 @@
 {{- define "pingdirectory.service-cluster" -}}
 {{- $top := index . 0 -}}
 {{- $v := index . 1 -}}
-{{- if or (eq "edge" ($v.image.tag | toString)) (hasPrefix "2012" ($v.image.tag | toString)) }}
 metadata:
   annotations:
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
   publishNotReadyAddresses: true
-{{- end -}}
 {{- end -}}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -3,6 +3,11 @@
 
 ## Release 0.4.2
 
+* [Issue #83](https://github.com/pingidentity/helm-charts/issues/83) - Remove old pingdirectory tag check when creating service-cluster.
+  This caused issues when creating a pingdirectory deployment with most recent tags (tags other than edge or 2012).
+
+## Release 0.4.2
+
 * [Issue #79](https://github.com/pingidentity/helm-charts/issues/79) - Adding support for product PingDataGovernance PAP
 * [Issue #78](https://github.com/pingidentity/helm-charts/issues/78) - Adding support to provide affinity definition to the workload of a product.
 


### PR DESCRIPTION
* [Issue #83](https://github.com/pingidentity/helm-charts/issues/83) - Remove old pingdirectory tag check when creating service-cluster.  This caused issues when creating a pingdirectory deployment with most recent tags (tags other than edge or 2012).