### PR TITLE
Release 0.4.4

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -8,8 +8,9 @@ name: ping-devops
 # 0.4.1 - Refer to http://helm.pingidentity.com/release-notes/#release-041
 # 0.4.2 - Refer to http://helm.pingidentity.com/release-notes/#release-042
 # 0.4.3 - Refer to http://helm.pingidentity.com/release-notes/#release-043
+# 0.4.4 - Refer to http://helm.pingidentity.com/release-notes/#release-044
 ########################################################################
-version: 0.4.3
+version: 0.4.4
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/

--- a/charts/ping-devops/templates/pinglib/_workload.tpl
+++ b/charts/ping-devops/templates/pinglib/_workload.tpl
@@ -308,11 +308,11 @@ volumes:
 
 {{- define "pinglib.workload.volumeMounts" -}}
 {{ $v := . }}
-volumeMounts:
 {{ range tuple "secretVolumes" "configMapVolumes" }}
 {{ $volType := . }}
 {{- range $volName, $volVal := (index $v .) }}
 {{- range $keyName, $keyVal := $volVal.items }}
+volumeMounts:
 - name: {{ $volName }}
   mountPath: {{ $keyVal }}
   subPath: {{ base $keyVal }}

--- a/charts/ping-devops/templates/pinglib/_workload.tpl
+++ b/charts/ping-devops/templates/pinglib/_workload.tpl
@@ -280,10 +280,10 @@ securityContext:
 ------------------------------------------------------*/}}
 {{- define "pinglib.workload.volumes" -}}
 {{ $v := . }}
-volumes:
 {{ range tuple "secretVolumes" "configMapVolumes" }}
 {{ $volType := . }}
 {{- range $volName, $volVal := (index $v .) }}
+volumes:
 - name: {{ $volName }}
   {{- if eq $volType "secretVolumes" }}
   secret:

--- a/charts/ping-devops/templates/pinglib/_workload.tpl
+++ b/charts/ping-devops/templates/pinglib/_workload.tpl
@@ -198,11 +198,12 @@ spec:
     {{- $host := include "pinglib.addreleasename" (list $top $v $prod) }}
     {{- $waitForServices := (index $top.Values $prod).services }}
     {{- $port := (index $waitForServices $val.service).servicePort | quote }}
+    {{- $timeout := printf "-t %d" (int (default 30 $val.timeoutSeconds )) -}}
     {{- $server := printf "%s:%s" $host $port }}
 - name: wait-for-{{ $prod }}-init
   imagePullPolicy: {{ $v.image.pullPolicy }}
   image: {{ $v.externalImage.pingtoolkit }}
-  command: ['sh', '-c', 'echo "Waiting for {{ $server }}..." && wait-for {{ $server }} -- echo "{{ $server }} running"']
+  command: ['sh', '-c', 'echo "Waiting for {{ $server }}..." && wait-for {{ $server }} {{ $timeout }} -- echo "{{ $server }} running"']
   {{ include "pinglib.workload.init.default.resources" . | nindent 2 }}
   {{ include "pinglib.workload.init.default.securityContext" . | nindent 2 }}
     {{- end }}
@@ -269,14 +270,18 @@ securityContext:
   template volumes and volumeMounts expect a struture
   like:
 
-  secretVolumes:
-    ping-license:
-      type: secret
-      name: pingfederate-license
-      items:
-        license: /opt/in/instance/server/default/conf/pingfederate.lic
-        hello: /opt/in/instance/server/default/hello.txt
+  pingfederate-admin
+    secretVolumes:
+      pingfederate-license:
+        items:
+          license: /opt/in/instance/server/default/conf/pingfederate.lic
+          hello: /opt/in/instance/server/default/hello.txt
+
   configMapVolumes:
+    pingfederate-props:
+        items:
+          pf-props: /opt/in/etc/pingfederate.properties
+
 ------------------------------------------------------*/}}
 {{- define "pinglib.workload.volumes" -}}
 {{ $v := . }}

--- a/charts/ping-devops/templates/pinglib/_workload.tpl
+++ b/charts/ping-devops/templates/pinglib/_workload.tpl
@@ -198,7 +198,7 @@ spec:
     {{- $host := include "pinglib.addreleasename" (list $top $v $prod) }}
     {{- $waitForServices := (index $top.Values $prod).services }}
     {{- $port := (index $waitForServices $val.service).servicePort | quote }}
-    {{- $timeout := printf "-t %d" (int (default 30 $val.timeoutSeconds )) -}}
+    {{- $timeout := printf "-t %d" (int (default 300 $val.timeoutSeconds )) -}}
     {{- $server := printf "%s:%s" $host $port }}
 - name: wait-for-{{ $prod }}-init
   imagePullPolicy: {{ $v.image.pullPolicy }}

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -230,38 +230,6 @@ global:
     #     name: my-example-secrets
     #     optional: true
 
-    ############################################################
-    # volumeMounts
-    #
-    # Provide ability to mount secrets and configMaps into
-    # container as volumes.
-    #
-    # volumeMounts:
-    #   {name for mount}:
-    #     name: {custom-name for secret/configMap}   # OPTIONAL: If set, secret/conficMap will have this name
-    #                                                # DEFAULT : {product w/ rel-name}-{volMount name}-{type}
-    #
-    #     type: <secret|configMap>                   # REQUIRED: secret or configMap
-    #
-    #     localFile: <path to file>                  # OPTIONAL: If set, secret/configMap will be created
-    #                                                # DEFAULT : secret/configMap not created, expected to be available
-    #
-    #     mountPath: <path to mount in container>    # REQUIRED: Path in container to mount secret/configMap
-    volumeMounts:
-      license:
-        name: my-own-secret-name                         # OPTIONAL: If set, secret will have this name otherwise
-                                                        # DEFAULT : {rel-name-product}-license-secret
-        type: secret
-        containerMountPath: /opt/in/pd.profile/server-root/pre-setup/PingDirectory.lic
-      hook-add-something:
-        name: my-own-secret-name                         # OPTIONAL: If set, secret will have this name otherwise
-                                                        # DEFAULT : {rel-name-product}-license-secret
-        type: congigMap
-        localFile: my-license/pingdirectory-8.1.lic      # OPTIONAL: If set, secret will be created by helm
-                                                        # DEFAULT : Secret is expected to be available
-        containerMountPath: /opt/in/pd.profile/server-root/pre-setup/PingDirectory.lic
-
-
   ############################################################
   # Probes
   #

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -230,6 +230,38 @@ global:
     #     name: my-example-secrets
     #     optional: true
 
+    ############################################################
+    # volumeMounts
+    #
+    # Provide ability to mount secrets and configMaps into
+    # container as volumes.
+    #
+    # volumeMounts:
+    #   {name for mount}:
+    #     name: {custom-name for secret/configMap}   # OPTIONAL: If set, secret/conficMap will have this name
+    #                                                # DEFAULT : {product w/ rel-name}-{volMount name}-{type}
+    #
+    #     type: <secret|configMap>                   # REQUIRED: secret or configMap
+    #
+    #     localFile: <path to file>                  # OPTIONAL: If set, secret/configMap will be created
+    #                                                # DEFAULT : secret/configMap not created, expected to be available
+    #
+    #     mountPath: <path to mount in container>    # REQUIRED: Path in container to mount secret/configMap
+    volumeMounts:
+      license:
+        name: my-own-secret-name                         # OPTIONAL: If set, secret will have this name otherwise
+                                                        # DEFAULT : {rel-name-product}-license-secret
+        type: secret
+        containerMountPath: /opt/in/pd.profile/server-root/pre-setup/PingDirectory.lic
+      hook-add-something:
+        name: my-own-secret-name                         # OPTIONAL: If set, secret will have this name otherwise
+                                                        # DEFAULT : {rel-name-product}-license-secret
+        type: congigMap
+        localFile: my-license/pingdirectory-8.1.lic      # OPTIONAL: If set, secret will be created by helm
+                                                        # DEFAULT : Secret is expected to be available
+        containerMountPath: /opt/in/pd.profile/server-root/pre-setup/PingDirectory.lic
+
+
   ############################################################
   # Probes
   #
@@ -319,6 +351,22 @@ pingfederate-admin:
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
     SERVER_PROFILE_PATH: getting-started/pingfederate
+
+  # Example: Pulling in a secret (called pingfederate-license) into container
+  #          mounting the name (license) value into a file (/opt/in/.../pingfederate.lic)
+  #
+  # secretVolumes:
+  #   pingfederate-license:
+  #     items:
+  #       license: /opt/in/instance/server/default/conf/pingfederate.lic
+
+  # Example: Pulling in a configMap (called pingfederate-props) into container
+  #          mounting the name (pf-props) value into a file (/opt/in/.../pingfederate.properties)
+  #
+  # configMapVolumes:
+  #  pingfederate-props:
+  #     items:
+  #      pf-props: /opt/in/etc/pingfederate.properties
 
   services:
     https:

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -315,6 +315,7 @@ pingfederate-admin:
   #   waitFor:
   #     pingdirectory:
   #       service: ldaps
+  #       timeoutSeconds: 300
 
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
@@ -377,6 +378,7 @@ pingfederate-engine:
     waitFor:
       pingfederate-admin:
         service: https
+        timeoutSeconds: 300
 
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
@@ -674,6 +676,7 @@ pingaccess-admin:
   #   waitFor:
   #     pingfederate-admin:
   #       service: https
+  #       timeoutSeconds: 300
 
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
@@ -715,6 +718,7 @@ pingaccess-engine:
     waitFor:
       pingaccess-admin:
         service: https
+        timeoutSeconds: 300
 
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git

--- a/docs/config/volume-mounts.md
+++ b/docs/config/volume-mounts.md
@@ -1,0 +1,45 @@
+# VolumeMounts Configuration
+
+Provides support for importing a secret containing license into the container.
+
+## Global/Product Section
+
+Adds ability to add secret and configMap data to a container via a VolumeMount.  A good use of this practice - bringing product
+licenses into the container.
+
+!!! note "Example of creating 3 volume mounts in container from secret and configMap"
+    ```yaml
+    pingfederate-admin
+      secretVolumes:
+        pingfederate-license:
+          items:
+            license: /opt/in/instance/server/default/conf/pingfederate.lic
+            hello: /opt/in/instance/server/default/hello.txt
+
+      configMapVolumes:
+      pingfederate-props:
+          items:
+            pf-props: /opt/in/etc/pingfederate.properties
+    ```
+
+In this case, a secret (called pingfederate-license) and configMap (called pingfederate-props) will bring in a
+couple of key values (license, hello) and (pf-props) into the container as specific files. The results will looks like:
+
+!!! note "Example of kubectl describe of pingfederate-admin container"
+    ```
+    Containers:
+      pingfederate-admin:
+        Mounts:
+          /opt/in/etc/pingfederate.properties from pingfederate-props (ro,path="pingfederate.properties")
+          /opt/in/instance/server/default/conf/pingfederate.lic from pingfederate-license (ro,path="pingfederate.lic")
+          /opt/in/instance/server/default/hello.txt from pingfederate-license (ro,path="hello.txt")
+    Volumes:
+      pingfederate-license:
+        Type:        Secret (a volume populated by a Secret)
+        SecretName:  pingfederate-license
+        Optional:    false
+      pingfederate-props:
+        Type:      ConfigMap (a volume populated by a ConfigMap)
+        Name:      pingfederate-props
+        Optional:  false
+    ```

--- a/docs/config/volume-mounts.md
+++ b/docs/config/volume-mounts.md
@@ -4,7 +4,7 @@ Provides support for importing a secret containing license into the container.
 
 ## Global/Product Section
 
-Adds ability to add secret and configMap data to a container via a VolumeMount.  A good use of this practice - bringing product
+Adds ability to use secret and configMap data in a container via a VolumeMount.  A common use for this - bringing product
 licenses into the container.
 
 !!! note "Example of creating 3 volume mounts in container from secret and configMap"
@@ -21,6 +21,8 @@ licenses into the container.
             items:
               pf-props: /opt/in/etc/pingfederate.properties
     ```
+
+> [Secrets](https://kubernetes.io/docs/tasks/configmap-secret/managing-secret-using-kubectl) and [ConfigMaps](https://kubernetes.io/docs/concepts/configuration/configmap/) must be created in the cluster prior to deploying the helm chart.
 
 In this case, a secret (called pingfederate-license) and configMap (called pingfederate-props) will bring in a
 couple of key values (license, hello) and (pf-props) into the container as specific files. The results will looks like:

--- a/docs/config/volume-mounts.md
+++ b/docs/config/volume-mounts.md
@@ -17,9 +17,9 @@ licenses into the container.
             hello: /opt/in/instance/server/default/hello.txt
 
       configMapVolumes:
-      pingfederate-props:
-          items:
-            pf-props: /opt/in/etc/pingfederate.properties
+        pingfederate-props:
+            items:
+              pf-props: /opt/in/etc/pingfederate.properties
     ```
 
 In this case, a secret (called pingfederate-license) and configMap (called pingfederate-props) will bring in a

--- a/docs/config/workload.md
+++ b/docs/config/workload.md
@@ -76,8 +76,8 @@ global:
     ```
 
 !!! note "WaitFor"
-    For each product, a `waitFor` structure providing the name, service and timeout (in seconds)
-    that should be waited on before the running container con continue.  This
+    For each product, a `waitFor` structure providing the name, service and timeout, in seconds,
+    that should be waited (defaults to 300 if not provided) on before the running container con continue.  This
     will inject an initContainer using the PingToolkit wait-for utility until it
     can `nc host:port` before continuing.
 
@@ -88,8 +88,10 @@ global:
         waitFor:
           pingdirectory:
             service: ldaps
+            timeoutSeconds: 600
           pingdatagovernance:
             service: https
+            timeoutSeconds: 300
     ```
 
     * By default, the `pingfederate-engine` will waitFor `pingfederate-admin` before it starts.

--- a/docs/config/workload.md
+++ b/docs/config/workload.md
@@ -74,3 +74,23 @@ global:
             runAsUser: 3000
             fsGroup: 2000
     ```
+
+!!! note "WaitFor"
+    For each product, a `waitFor` structure providing the name, service and timeout (in seconds)
+    that should be waited on before the running container con continue.  This
+    will inject an initContainer using the PingToolkit wait-for utility until it
+    can `nc host:port` before continuing.
+
+    Example: PingFederate Admin waiting on pingdirectory ldaps service to be available
+    ```yaml
+    pingfederate-admin:
+      container:
+        waitFor:
+          pingdirectory:
+            service: ldaps
+          pingdatagovernance:
+            service: https
+    ```
+
+    * By default, the `pingfederate-engine` will waitFor `pingfederate-admin` before it starts.
+    * By default, the `pingaccess-engine` will waitFor `pingaccess-admin` before it starts.

--- a/docs/examples/everything.yaml
+++ b/docs/examples/everything.yaml
@@ -19,6 +19,7 @@ pingaccess-admin:
     waitFor:
       pingfederate-engine:
         service: https
+        timeoutSeconds: 300
 
 pingaccess-engine:
   enabled: true

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,7 +1,48 @@
 # Release Notes
 
 
-## Release 0.4.2
+## Release 0.4.4
+
+* [Issue #80](https://github.com/pingidentity/helm-charts/issues/80) - Add support for importing a secret containing license into the container.
+  Adds ability to add secret and configMap data to a container via a VolumeMount.  A good use of this practice - bringing product
+  licenses into the container.
+
+    !!! note "Example of creating 3 volume mounts in container from secret and configMap"
+        ```yaml
+        pingfederate-admin
+          secretVolumes:
+            pingfederate-license:
+              items:
+                license: /opt/in/instance/server/default/conf/pingfederate.lic
+                hello: /opt/in/instance/server/default/hello.txt
+
+          configMapVolumes:
+          pingfederate-props:
+              items:
+                pf-props: /opt/in/etc/pingfederate.properties
+        ```
+  In this case, a secret (called pingfederate-license) and configMap (called pingfederate-props) will bring in a
+  couple of key values (license, hello) and (pf-props) into the container as specific files. The results will looks like:
+
+    !!! note "Example of kubectl describe of pingfederate-admin container"
+        ```
+        Containers:
+          pingfederate-admin:
+            Mounts:
+              /opt/in/etc/pingfederate.properties from pingfederate-props (ro,path="pingfederate.properties")
+              /opt/in/instance/server/default/conf/pingfederate.lic from pingfederate-license (ro,path="pingfederate.lic")
+              /opt/in/instance/server/default/hello.txt from pingfederate-license (ro,path="hello.txt")
+        Volumes:
+          pingfederate-license:
+            Type:        Secret (a volume populated by a Secret)
+            SecretName:  pingfederate-license
+            Optional:    false
+          pingfederate-props:
+            Type:      ConfigMap (a volume populated by a ConfigMap)
+            Name:      pingfederate-props
+            Optional:  false
+        ```
+## Release 0.4.3
 
 * [Issue #83](https://github.com/pingidentity/helm-charts/issues/83) - Remove old pingdirectory tag check when creating service-cluster.
   This caused issues when creating a pingdirectory deployment with most recent tags (tags other than edge or 2012).

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -17,9 +17,9 @@
                 hello: /opt/in/instance/server/default/hello.txt
 
           configMapVolumes:
-          pingfederate-props:
-              items:
-                pf-props: /opt/in/etc/pingfederate.properties
+            pingfederate-props:
+                items:
+                  pf-props: /opt/in/etc/pingfederate.properties
         ```
   In this case, a secret (called pingfederate-license) and configMap (called pingfederate-props) will bring in a
   couple of key values (license, hello) and (pf-props) into the container as specific files. The results will looks like:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,6 +53,7 @@ nav:
       - PrivateCerts: "config/private-cert.md"
       - Service: "config/service.md"
       - Vault: "config/vault.md"
+      - VolumeMounts: "config/volume-mounts.md"
       - Workload: "config/workload.md"
   - Examples:
       - Introduction: "examples/index.md"


### PR DESCRIPTION
From Release Notes:

* [Issue #80](https://github.com/pingidentity/helm-charts/issues/80) - Add support for importing a secret containing license into the container.
  Adds ability to add secret and configMap data to a container via a VolumeMount.  A good use of this practice - bringing product
  licenses into the container.

    !!! note "Example of creating 3 volume mounts in container from secret and configMap"
        ```yaml
        pingfederate-admin
          secretVolumes:
            pingfederate-license:
              items:
                license: /opt/in/instance/server/default/conf/pingfederate.lic
                hello: /opt/in/instance/server/default/hello.txt

          configMapVolumes:
          pingfederate-props:
              items:
                pf-props: /opt/in/etc/pingfederate.properties
        ```
  In this case, a secret (called pingfederate-license) and configMap (called pingfederate-props) will bring in a
  couple of key values (license, hello) and (pf-props) into the container as specific files. The results will looks like:

    !!! note "Example of kubectl describe of pingfederate-admin container"
        ```
        Containers:
          pingfederate-admin:
            Mounts:
              /opt/in/etc/pingfederate.properties from pingfederate-props (ro,path="pingfederate.properties")
              /opt/in/instance/server/default/conf/pingfederate.lic from pingfederate-license (ro,path="pingfederate.lic")
              /opt/in/instance/server/default/hello.txt from pingfederate-license (ro,path="hello.txt")
        Volumes:
          pingfederate-license:
            Type:        Secret (a volume populated by a Secret)
            SecretName:  pingfederate-license
            Optional:    false
          pingfederate-props:
            Type:      ConfigMap (a volume populated by a ConfigMap)
            Name:      pingfederate-props
            Optional:  false
        ```