### PR TITLE
Issue #89 - Adding new defaults for cpu and memory

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -9,9 +9,10 @@ name: ping-devops
 # 0.4.2 - Refer to http://helm.pingidentity.com/release-notes/#release-042
 # 0.4.3 - Refer to http://helm.pingidentity.com/release-notes/#release-043
 # 0.4.4 - Refer to http://helm.pingidentity.com/release-notes/#release-044
+# 0.4.5 - Refer to http://helm.pingidentity.com/release-notes/#release-045
 ########################################################################
-version: 0.4.4
+version: 0.4.5
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/
-appVersion: "2.0"
+appVersion: "2101"

--- a/charts/ping-devops/templates/NOTES.txt
+++ b/charts/ping-devops/templates/NOTES.txt
@@ -1,8 +1,8 @@
 {{ include "pinglib.notes.header" . }}
-{{- $format := "%-1.1s %-21.21s %-11.11s %5.5s" }}
+{{- $format := "%-1.1s %-21.21s %-11.11s %-5.5s %-5.5s %-5.5s %-5.5s %5.5s" }}
 #
-#  {{ printf $format " " "       Product       " " Workload  " " Ing "}}
-#  {{ printf $format " " "---------------------" "-----------" "-----"}}
+#  {{ printf $format " " "       Product       " " Workload  " "cpu-R" "cpu-L" "mem-R" "mem-L" " Ing "}}
+#  {{ printf $format " " "---------------------" "-----------" "-----"  "-----"  "-----"  "-----" "-----"}}
 {{- $products := list "pingaccess-admin" "pingaccess-engine" "pingdataconsole" "pingdatagovernance" "pingdatagovernancepap" "pingdatasync" "pingdelegator" "pingdirectory" "pingfederate-admin" "pingfederate-engine" "---" "ldap-sdk-tools" "pd-replication-timing" }}
 {{- range $prodName := $products }}
 {{- if eq $prodName "---" }}
@@ -10,9 +10,9 @@
 {{- end }}
 {{- with (index $.Values $prodName)}}
     {{- if .enabled }}
-#  {{ printf $format "√" $prodName (.workload.type | lower) (toString .ingress.enabled) }}
+#  {{ printf $format "√" $prodName (.workload.type | lower) (toString .container.resources.requests.cpu) (toString .container.resources.limits.cpu) (toString .container.resources.requests.memory) (toString .container.resources.limits.memory) (toString .ingress.enabled) }}
     {{- else }}
-#  {{ printf $format "" $prodName "" "" }}
+#  {{ printf $format "" $prodName "" "" "" "" "" "" }}
     {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -206,15 +206,15 @@ global:
     # replicaCount - Instructs Deployment/StatefulSet now many containers to run
     replicaCount: 1
 
-    # resources - Reqeust  0.5 cpu/0.5 GB
-    #             Limit    4.0 cpu/8.0 GB
+    # resources - Reqeust  0 cpu/0 GB
+    #             Limit    4 cpu/0 GB
     resources:
       requests:
-        cpu: 500m
-        memory: 500Mi
+        cpu: 0
+        memory: 0
       limits:
-        cpu: 4
-        memory: 8Gi
+        cpu: 0
+        memory: 0
     nodeSelector: {}
     tolerations: []
     affinity: {}
@@ -303,6 +303,15 @@ pingfederate-admin:
   image:
     name: pingfederate
 
+  container:
+    resources:
+      requests:
+        cpu: 0
+        memory: 1Gi
+      limits:
+        cpu: 2
+        memory: 4Gi
+
   workload:
     deployment:
       strategy:
@@ -375,6 +384,13 @@ pingfederate-engine:
     name: pingfederate
 
   container:
+    resources:
+      requests:
+        cpu: 0
+        memory: 1Gi
+      limits:
+        cpu: 2
+        memory: 4Gi
     waitFor:
       pingfederate-admin:
         service: https
@@ -445,11 +461,12 @@ pingdirectory:
     replicaCount: 2
     resources:
       requests:
-        cpu: 500m
+        cpu: 0
         memory: 2Gi
       limits:
-        cpu: 8000m
+        cpu: 2
         memory: 8Gi
+
     terminationGracePeriodSeconds: 300
     # Example affinity for typical directory installation
     #
@@ -537,6 +554,15 @@ pingdelegator:
   image:
     name: pingdelegator
 
+  container:
+    resources:
+      requests:
+        cpu: 0
+        memory: 32Mi
+      limits:
+        cpu: 500m
+        memory: 64Mi
+
   publicPort: 443
 
   tokenProvider:
@@ -578,6 +604,15 @@ pingdatasync:
   image:
     name: pingdatasync
 
+  container:
+    resources:
+      requests:
+        cpu: 0
+        memory: .75Gi
+      limits:
+        cpu: 2
+        memory: 2Gi
+
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
     SERVER_PROFILE_PATH: simple-sync/pingdatasync
@@ -600,6 +635,15 @@ pingdatagovernance:
   name: pingdatagovernance
   image:
     name: pingdatagovernance
+
+  container:
+    resources:
+      requests:
+        cpu: 0
+        memory: 1.5Gi
+      limits:
+        cpu: 2
+        memory: 4Gi
 
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
@@ -637,6 +681,15 @@ pingdatagovernancepap:
   image:
     name: pingdatagovernancepap
 
+  container:
+    resources:
+      requests:
+        cpu: 0
+        memory: .75Gi
+      limits:
+        cpu: 2
+        memory: 2Gi
+
   envs:
     SERVER_PROFILE_URL: https://www.github.com/pingidentity/pingidentity-server-profiles.git
     SERVER_PROFILE_PATH: pdg-pap-integration/pingdatagovernancepap
@@ -668,6 +721,15 @@ pingaccess-admin:
   name: pingaccess-admin
   image:
     name: pingaccess
+
+  container:
+    resources:
+      requests:
+        cpu: 0
+        memory: 1Gi
+      limits:
+        cpu: 2
+        memory: 4Gi
 
   # Example: If PingAccess Admin relies on pingfederate-admin for AuthN
   #          Creates init container wait-for on pingfederate-admin https service
@@ -715,6 +777,13 @@ pingaccess-engine:
     name: pingaccess
 
   container:
+    resources:
+      requests:
+        cpu: 0
+        memory: 1Gi
+      limits:
+        cpu: 2
+        memory: 4Gi
     waitFor:
       pingaccess-admin:
         service: https
@@ -751,6 +820,15 @@ pingdataconsole:
   name: pingdataconsole
   image:
     name: pingdataconsole
+
+  container:
+    resources:
+      requests:
+        cpu: 0
+        memory: .5Gi
+      limits:
+        cpu: 2
+        memory: 2Gi
 
   defaultLogin:
     server:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,41 @@
 # Release Notes
 
 
+## Release 0.4.5
+
+* [Issue #89](https://github.com/pingidentity/helm-charts/issues/89) - Update default workload resource cpu/memory request sizes.
+
+  Updating defaults to create a usage better reflecting actual memory usage by product. And minimizing amount of CPU needed
+  as testing generally utilizes very little.  Of course, it is definitely recommended that production deployments specify amount of
+  cpu and memory required and limited to.
+
+  Current defaults are set to:
+
+  ```
+  #-------------------------------------------------------------------------------------
+  # Ping DevOps
+  #
+  # Description: All Ping Identity product images with integration
+  #-------------------------------------------------------------------------------------
+  #
+  #           Product         Workload   cpu-R cpu-L mem-R mem-L  Ing
+  #    --------------------- ----------- ----- ----- ----- ----- -----
+  #  √ pingaccess-admin      deployment  0     2     1Gi   4Gi   false
+  #  √ pingaccess-engine     deployment  0     2     1Gi   4Gi   false
+  #  √ pingdataconsole       deployment  0     2     .5Gi  2Gi   false
+  #  √ pingdatagovernance    deployment  0     2     1.5Gi 4Gi   false
+  #  √ pingdatagovernancepap deployment  0     2     .75Gi 2Gi   false
+  #  √ pingdatasync          deployment  0     2     .75Gi 2Gi   false
+  #  √ pingdelegator         deployment  0     500m  32Mi  64Mi  false
+  #  √ pingdirectory         statefulset 0     2     2Gi   8Gi   false
+  #  √ pingfederate-admin    deployment  0     2     1Gi   4Gi   false
+  #  √ pingfederate-engine   deployment  0     2     1Gi   4Gi   false
+  #
+  #  √ ldap-sdk-tools        deployment  0     0     0     0     false
+  #  √ pd-replication-timing deployment  0     0     0     0     false
+  #
+  #-------------------------------------------------------------------------------------
+  ```
 ## Release 0.4.4
 
 * [Issue #80](https://github.com/pingidentity/helm-charts/issues/80) - Add support for importing a secret containing license into the container.


### PR DESCRIPTION
* [Issue #89](https://github.com/pingidentity/helm-charts/issues/89) - Update default workload resource cpu/memory request sizes.

  Updating defaults to create a usage better reflecting actual memory usage by product. And minimizing amount of CPU needed
  as testing generally utilizes very little.  Of course, it is definitely recommended that production deployments specify amount of
  cpu and memory required and limited to.

  Current defaults are set to:

  ```
  #-------------------------------------------------------------------------------------
  # Ping DevOps
  #
  # Description: All Ping Identity product images with integration
  #-------------------------------------------------------------------------------------
  #
  #           Product         Workload   cpu-R cpu-L mem-R mem-L  Ing
  #    --------------------- ----------- ----- ----- ----- ----- -----
  #  √ pingaccess-admin      deployment  0     2     1Gi   4Gi   false
  #  √ pingaccess-engine     deployment  0     2     1Gi   4Gi   false
  #  √ pingdataconsole       deployment  0     2     .5Gi  2Gi   false
  #  √ pingdatagovernance    deployment  0     2     1.5Gi 4Gi   false
  #  √ pingdatagovernancepap deployment  0     2     .75Gi 2Gi   false
  #  √ pingdatasync          deployment  0     2     .75Gi 2Gi   false
  #  √ pingdelegator         deployment  0     500m  32Mi  64Mi  false
  #  √ pingdirectory         statefulset 0     2     2Gi   8Gi   false
  #  √ pingfederate-admin    deployment  0     2     1Gi   4Gi   false
  #  √ pingfederate-engine   deployment  0     2     1Gi   4Gi   false
  #
  #  √ ldap-sdk-tools        deployment  0     0     0     0     false
  #  √ pd-replication-timing deployment  0     0     0     0     false
  #
  #-------------------------------------------------------------------------------------
  ```