### PR TITLE
Release 0.4.8

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -12,8 +12,9 @@ name: ping-devops
 # 0.4.5 - Refer to http://helm.pingidentity.com/release-notes/#release-045
 # 0.4.6 - Refer to http://helm.pingidentity.com/release-notes/#release-046
 # 0.4.7 - Refer to http://helm.pingidentity.com/release-notes/#release-047
+# 0.4.8 - Refer to http://helm.pingidentity.com/release-notes/#release-048
 ########################################################################
-version: 0.4.7
+version: 0.4.8
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -410,9 +410,18 @@ pingfederate-engine:
     SERVER_PROFILE_PATH: getting-started/pingfederate
     PF_ADMIN_PORT: "9999"
 
+  #############################################################
+  # Horizontal Pod Autoscaling
+  # By defult this is disabled, since there dependencies to the containers
+  # CPU and/or Memory limites.
+  #
+  # If enabled, ensure that a proper container.resource.request.cpu limit is set
+  # and coordinated with the a targetCPUUtilizationPercentage or
+  # targetMemoryUtilizationPercentage
+  #############################################################
   clustering:
     autoscaling:
-      enabled: true
+      enabled: false
       minReplicas: 1
       maxReplicas: 4
       targetCPUUtilizationPercentage: 75

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Release 0.4.8
+
+* [Issue #100](https://github.com/pingidentity/helm-charts/issues/100) - Change pingfederate-engine HPA to a default of disabled
+
+    Changing the default value `pingfederate-engine.clustering.autoscaling.enabled=false`, since the default
+    CPU Request is set to 0.
 
 ## Release 0.4.7
 


### PR DESCRIPTION
* [Issue #100](https://github.com/pingidentity/helm-charts/issues/100) - Change pingfederate-engine HPA to a default of disabled

    Changing the default value `pingfederate-engine.clustering.autoscaling.enabled=false`, since the default
    CPU Request is set to 0.
