### PR TITLE
Release 0.4.9 - Update default global image tag to 2102 (Feb 2021)

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -13,8 +13,9 @@ name: ping-devops
 # 0.4.6 - Refer to http://helm.pingidentity.com/release-notes/#release-046
 # 0.4.7 - Refer to http://helm.pingidentity.com/release-notes/#release-047
 # 0.4.8 - Refer to http://helm.pingidentity.com/release-notes/#release-048
+# 0.4.9 - Refer to http://helm.pingidentity.com/release-notes/#release-049
 ########################################################################
-version: 0.4.8
+version: 0.4.9
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -50,6 +50,8 @@ global:
   # If set to true, then an internal certificate secret will
   # be created along with mount of the certificate in
   # /run/secrets/internal-cert (creates a tls.crt and tls.key)
+  #
+  #      privateCert.generate: {true | false}
   ############################################################
   privateCert:
     generate: false
@@ -93,7 +95,7 @@ global:
   image:
     repository: pingidentity
     name:
-    tag: "2101"
+    tag: "2102"
     pullPolicy: Always
 
   ############################################################

--- a/docs/examples/everything.yaml
+++ b/docs/examples/everything.yaml
@@ -3,11 +3,6 @@
 #
 ############################################################
 
-
-global:
-  image:
-    tag: "edge"  # Uses images with the "edge" tag
-
 pingaccess-admin:
   enabled: true
   privateCert:

--- a/docs/examples/pingfederate.yaml
+++ b/docs/examples/pingfederate.yaml
@@ -3,10 +3,6 @@
 #
 ############################################################
 
-global:
-  image:
-    tag: "edge"  # Uses images with the "edge" tag
-
 ############################################################
 # Ping DevOps Service Customizations
 #

--- a/docs/examples/simple-sync.yaml
+++ b/docs/examples/simple-sync.yaml
@@ -3,11 +3,6 @@
 #
 ############################################################
 
-
-global:
-  image:
-    tag: "edge"  # Uses images with the "edge" tag
-
 pingdataconsole:
   enabled: true
 

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+
+## Release 0.4.9
+
+* [Issue #104](https://github.com/pingidentity/helm-charts/issues/104) - Update default global image tag to 2102 (Feb 2021)
+
+    Update the default global image tag in base values.yaml and remove edge from example yamls.
+
+
 ## Release 0.4.8
 
 * [Issue #100](https://github.com/pingidentity/helm-charts/issues/100) - Change pingfederate-engine HPA to a default of disabled


### PR DESCRIPTION
-   Update the default global image tag in base values.yaml and remove edge from example yamls.
