### PR TITLE
Release 0.5.0

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,18 +4,13 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.4.0 - Refer to http://helm.pingidentity.com/release-notes/#release-040
-# 0.4.1 - Refer to http://helm.pingidentity.com/release-notes/#release-041
-# 0.4.2 - Refer to http://helm.pingidentity.com/release-notes/#release-042
-# 0.4.3 - Refer to http://helm.pingidentity.com/release-notes/#release-043
-# 0.4.4 - Refer to http://helm.pingidentity.com/release-notes/#release-044
-# 0.4.5 - Refer to http://helm.pingidentity.com/release-notes/#release-045
 # 0.4.6 - Refer to http://helm.pingidentity.com/release-notes/#release-046
 # 0.4.7 - Refer to http://helm.pingidentity.com/release-notes/#release-047
 # 0.4.8 - Refer to http://helm.pingidentity.com/release-notes/#release-048
 # 0.4.9 - Refer to http://helm.pingidentity.com/release-notes/#release-049
+# 0.5.0 - Refer to http://helm.pingidentity.com/release-notes/#release-050
 ########################################################################
-version: 0.4.9
+version: 0.5.0
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/

--- a/charts/ping-devops/templates/NOTES.txt
+++ b/charts/ping-devops/templates/NOTES.txt
@@ -1,9 +1,9 @@
 {{ include "pinglib.notes.header" . }}
-{{- $format := "%-1.1s %-21.21s %-11.11s %5.5s %5.5s %5.5s %5.5s %3.3s" }}
+{{- $format := "%-1.1s %-21.21s %-7.7s %-3.3s %2.2s %4.4s%1s%-4.4s %4.4s%1s%-4.4s %3.3s" }}
 #
-#  {{ printf $format " " "       Product       " " Workload  " "cpu-R" "cpu-L" "mem-R" "mem-L" "Ing"}}
-#  {{ printf $format " " "---------------------" "-----------" "-----"  "-----"  "-----"  "-----" "-----"}}
-#  {{ printf $format " " "global" "" (toString $.Values.global.container.resources.requests.cpu) (toString $.Values.global.container.resources.limits.cpu) (toString $.Values.global.container.resources.requests.memory) (toString $.Values.global.container.resources.limits.memory) (ternary " √ " "" $.Values.global.ingress.enabled) }}
+#  {{ printf $format " " "       Product       " "  tag  " "typ" " #" " cpu" " " "R/L " " mem" " " "R/L " "Ing"}}
+#  {{ printf $format " " "---------------------" "-------" "---" "--" "----" "-" "----" "----" "-" "----" "---"}}
+#  {{ printf $format " " "global" (toString $.Values.global.image.tag) "" "" (toString $.Values.global.container.resources.requests.cpu) "/" (toString $.Values.global.container.resources.limits.cpu) (toString $.Values.global.container.resources.requests.memory) "/" (toString $.Values.global.container.resources.limits.memory) (ternary " √ " "" $.Values.global.ingress.enabled) }}
 #
 {{- $products := list "pingaccess-admin" "pingaccess-engine" "pingdataconsole" "pingdatagovernance" "pingdatagovernancepap" "pingdatasync" "pingdelegator" "pingdirectory" "pingfederate-admin" "pingfederate-engine" "---" "ldap-sdk-tools" "pd-replication-timing" }}
 {{- range $prodName := $products }}
@@ -12,13 +12,16 @@
 {{- end }}
 {{- with (index $.Values $prodName)}}
     {{- $prodEnabled := ternary "√" "" .enabled }}
-    {{- $workload := ternary (.workload.type | lower) "" .enabled }}
+    {{- $tag := ternary (toString .image.tag) "" .enabled }}
+    {{- $workload := ternary (ternary "dep" "sts" (eq .workload.type "Deployment")) "" .enabled }}
+    {{- $numReplica := ternary (toString .container.replicaCount) "" .enabled }}
+    {{- $slash := ternary "/" "" .enabled }}
     {{- $cpur := ternary (toString .container.resources.requests.cpu) "" .enabled }}
     {{- $cpul := ternary (toString .container.resources.limits.cpu) "" .enabled }}
     {{- $memr := ternary (toString .container.resources.requests.memory) "" .enabled }}
     {{- $meml := ternary (toString .container.resources.limits.memory) "" .enabled }}
     {{- $ingEnabled := .enabled | ternary (ternary " √ " "" .ingress.enabled) "" }}
-#  {{ printf $format $prodEnabled $prodName $workload $cpur $cpul $memr $meml $ingEnabled  }}
+#  {{ printf $format $prodEnabled $prodName $tag $workload $numReplica $cpur $slash $cpul $memr $slash $meml $ingEnabled  }}
 {{- end }}
 {{- end }}
 #

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -52,9 +52,13 @@ global:
   # /run/secrets/internal-cert (creates a tls.crt and tls.key)
   #
   #      privateCert.generate: {true | false}
+  #      privateCert.additionalHosts: {optioanl array of hosts}
+  #      privateCert.additionalIPs: {optioanl array of IP Addresses}
   ############################################################
   privateCert:
     generate: false
+    additionalHosts: []
+    additioanlIPs: []
 
   ############################################################
   # Fields used to annotate secret hashicorp vault information

--- a/docs/config/private-cert.md
+++ b/docs/config/private-cert.md
@@ -16,9 +16,22 @@ global:
   # If set to true, then an internal certificate secret will
   # be created along with mount of the certificate in
   # /run/secrets/internal-cert (creates a tls.crt and tls.key)
+  #
+  # By default the Issuer of the cert will be the service name
+  # created by the Helm Chart.  Additionally, the ingress hosts,
+  # if enabled, will be added to the list of X509v3 Subject Alternative Name
+  #
+  # Use the additionalHosts and additionalIPs if additional custom
+  # names and ips are needed.
+  #
+  #      privateCert.generate: {true | false}
+  #      privateCert.additionalHosts: {optional array of hosts}
+  #      privateCert.additionalIPs: {optional array of IP Addresses}
   ############################################################
   privateCert:
     generate: false
+    additionalHosts: []
+    additioanlIPs: []
 ```
 
 ## Product Section
@@ -30,11 +43,15 @@ Generating an internal certificate is as simple setting the `privateCert.generat
 ```yaml
 pingaccess-admin:
   privateCert:
-    generate:false
+    generate:true
 ```
 
 This will ultimately create a secret named `{release-productname}-private-cert`
 containing a valid `tls.crt` and `tls.key`.
+
+By default the Issuer of the cert will be the service name
+created by the Helm Chart.  Additionally, the ingress hosts,
+if enabled, will be added to the list of `X509v3 Subject Alternative Name`
 
 The product image will then create an init container to generate a pkcs12 file that will
 be placed in `/run/secrets/private-keystore/keystore.env` that will be mounted into the

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,39 @@
 # Release Notes
 
 
+## Release 0.5.0
+
+* [Issue #103](https://github.com/pingidentity/helm-charts/issues/103) - Provide ability to add additional alt-names/alt-ips to private cert generation
+
+    Allow for a privateCert structure to contain optional arrays `additionalHosts` and `additionalIPs`:
+
+    ```
+    pingaccess-admin:
+      privateCert:
+        generate: true
+        additionalHosts:
+        - pingaccess-admin.west-cluster.example.com
+        - pa-admin.west-cluster.example.com
+        additionalIPs:
+        - 123.45.67.8
+    ```
+
+    In addition, if the ingress for the product is enabled, the host(s) created for that ingress will also be added to the alt-names.
+
+    The above example (with an ingress) will create a cert used by pingaccess-admin containing:
+
+    ```
+    Certificate:
+        Data:
+            ...
+        Signature Algorithm: sha256WithRSAEncryption
+            Issuer: CN=pingaccess-admin
+            ...
+            X509v3 extensions:
+                ...
+                X509v3 Subject Alternative Name:
+                    DNS:rel050-pa-pingaccess-admin.ping-devops.com. pingaccess-admin.west-cluster.example.com, DNS:pa-admin.west-cluster.example.com, IP Address:123.45.67.8
+    ```
 ## Release 0.4.9
 
 * [Issue #104](https://github.com/pingidentity/helm-charts/issues/104) - Update default global image tag to 2102 (Feb 2021)


### PR DESCRIPTION
* [Issue #103](https://github.com/pingidentity/helm-charts/issues/103) - Provide ability to add additional alt-names/alt-ips to private cert generation

    Allow for a privateCert structure to contain optional arrays `additionalHosts` and `additionalIPs`:

    ```
    pingaccess-admin:
      privateCert:
        generate: true
        additionalHosts:
        - pingaccess-admin.west-cluster.example.com
        - pa-admin.west-cluster.example.com
        additionalIPs:
        - 123.45.67.8
    ```

    In addition, if the ingress for the product is enabled, the host(s) created for that ingress will also be added to the alt-names.

    The above example (with an ingress) will create a cert used by pingaccess-admin containing:

    ```
    Certificate:
        Data:
            ...
        Signature Algorithm: sha256WithRSAEncryption
            Issuer: CN=pingaccess-admin
            ...
            X509v3 extensions:
                ...
                X509v3 Subject Alternative Name:
                    DNS:rel050-pa-pingaccess-admin.ping-devops.com. pingaccess-admin.west-cluster.example.com, DNS:pa-admin.west-cluster.example.com, IP Address:123.45.67.8
    ```