### PR TITLE
Release 0.5.3

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,10 +4,10 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.5.2 - Refer to http://helm.pingidentity.com/release-notes/#release-052
+# 0.5.3 - Refer to http://helm.pingidentity.com/release-notes/#release-053
 ########################################################################
-version: 0.5.2
+version: 0.5.3
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/
-appVersion: "2101"
+appVersion: "2103"

--- a/charts/ping-devops/templates/global/configmap.yaml
+++ b/charts/ping-devops/templates/global/configmap.yaml
@@ -1,7 +1,5 @@
 {{- include "pinglib.configmap" (list . "global") -}}
 
-
-
 {{- define "global.configmap" -}}
 {{- $top := index . 0 -}}
 {{- $v := index . 1 -}}
@@ -29,47 +27,4 @@ data:
   {{ include "global.public.host.port" (list $top $v "PDP_ENGINE" "pingdirectoryproxy") }}
   {{ include "global.public.host.port" (list $top $v "PF_ENGINE" "pingfederate-engine") }}
   {{ include "global.public.host.port" (list $top $v "PF_ADMIN" "pingfederate-admin") }}
-
-{{- end -}}
-
-
-{{- define "global.private.host.port" -}}
-{{- $top := index . 0 }}
-{{- $v := index . 1 }}
-{{- $envPrefix := index . 2 }}
-{{- $prodName := index . 3 }}
-{{- with (index $top.Values $prodName) }}
-{{- if .enabled }}
-  {{ $envPrefix }}_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (list $top $v .name) | quote }}
-  {{- range $serviceName, $val := .services }}
-  {{- if ne $serviceName "clusterExternalDNSHostname" }}
-  {{- if $val.dataService }}
-  {{ $envPrefix }}_PRIVATE_PORT_{{ $serviceName | replace "-" "_" | upper }}: {{ $val.servicePort | quote }}
-  {{- end }}
-  {{- end }}
-  {{- end }}
-{{- end }}
-{{- end }}
-{{- end -}}
-
-{{- define "global.public.host.port" -}}
-{{- $top := index . 0 }}
-{{- $v := index . 1 }}
-{{- $envPrefix := index . 2 }}
-{{- $prodName := index . 3 }}
-{{- with (index $top.Values $prodName) }}
-{{- if and .enabled .ingress }}
-{{- if .ingress.enabled }}
-{{- $services := (index $top.Values $prodName).services }}
-{{- range .ingress.hosts }}
-  {{ $envPrefix }}_PUBLIC_HOSTNAME: {{ include "pinglib.ingress.hostname" (list $top $v .host) | quote }}
-
-  {{- range .paths }}
-  {{ $envPrefix }}_PUBLIC_PORT_{{ .backend.serviceName | replace "-" "_" | upper }}: {{ (index $services .backend.serviceName).ingressPort | quote }}
-  {{- end }}
-
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end }}
 {{- end -}}

--- a/charts/ping-devops/templates/pinglib/_configmap.tpl
+++ b/charts/ping-devops/templates/pinglib/_configmap.tpl
@@ -17,3 +17,56 @@ data:
   {{- include "pinglib.merge.templates" (append . "configmap") -}}
 {{- end -}}
 
+
+{{/**********************************************************************
+   ** global.private.host.port
+   **
+   ** By default, all PRIVATE HOSTS/PORTS will be created even if the product isn't enabled.  This is done
+   ** so we don't cause all workloads to restart just because a new product is added and a global-var
+   ** configmap is generated.
+   **********************************************************************/}}
+{{- define "global.private.host.port" -}}
+{{- $top := index . 0 }}
+{{- $v := index . 1 }}
+{{- $envPrefix := index . 2 }}
+{{- $prodName := index . 3 }}
+{{- with (index $top.Values $prodName) }}
+  {{ $envPrefix }}_PRIVATE_HOSTNAME: {{ include "pinglib.addreleasename" (list $top $v .name) | quote }}
+  {{- range $serviceName, $val := .services }}
+    {{- if ne $serviceName "clusterExternalDNSHostname" }}
+      {{- if $val.dataService }}
+  {{ $envPrefix }}_PRIVATE_PORT_{{ $serviceName | replace "-" "_" | upper }}: {{ $val.servicePort | quote }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/**********************************************************************
+   ** global.public.host.port
+   **
+   ** By default, all PUBLIC HOSTS/PORTS will be created even if the product isn't enabled.  This is done
+   ** so we don't cause all workloads to restart just because a new product is added and a global-var
+   ** configmap is generated.
+   **********************************************************************/}}
+{{- define "global.public.host.port" -}}
+{{- $top := index . 0 }}
+{{- $v := index . 1 }}
+{{- $envPrefix := index . 2 }}
+{{- $prodName := index . 3 }}
+{{- with (index $top.Values $prodName) }}
+  {{- if .ingress }}
+    {{- if .ingress.enabled }}
+      {{- $services := (index $top.Values $prodName).services }}
+      {{- range .ingress.hosts }}
+  {{ $envPrefix }}_PUBLIC_HOSTNAME: {{ include "pinglib.ingress.hostname" (list $top $v .host) | quote }}
+
+        {{- range .paths }}
+  {{ $envPrefix }}_PUBLIC_PORT_{{ .backend.serviceName | replace "-" "_" | upper }}: {{ (index $services .backend.serviceName).ingressPort | quote }}
+        {{- end }}
+
+      {{- end }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -99,7 +99,7 @@ global:
   # By default the images uses will be indicated by these
   # variables.  An example might look like:
   #
-  #   pingidentity/pingdataconsole:2101
+  #   pingidentity/pingdataconsole:2103 (March, 2021)
   #
   # NOTE: image.name MUST be set in child chart
   #   Example: image.name: pingfederate
@@ -107,7 +107,7 @@ global:
   image:
     repository: pingidentity
     name:
-    tag: "2102"
+    tag: "2103"
     pullPolicy: Always
 
   ############################################################
@@ -209,18 +209,20 @@ global:
 
     # securityContext
     #
-    # Note: the majority of images will have issues when running with a
-    #       security context set by k8s, due to expecations of file system
-    #       permissions and ports.  Use with caution
-    # Currently unable to use - readOnlyRootFilesystem: true
-    securityContext: {}
+    # Note: The user (9031) and group (9999) represent the current user
+    #       and group used with PingIdentity images (except PingDelegator).
+    #       The fsGroup is set to same as group, however, it can be set to
+    #       any gid number.
+    #       The fsGroup is required for any wordloads that volumeMount
+    #       a pvc (i.e. StatefulSets)
+    securityContext:
+      fsGroup: 9999
+      # runAsUser: 9031
+      # runAsGroup: 9999
       # allowPrivilegeEscalation: false
       # capabilities:
       #   drop:
       #   - ALL
-      # runAsGroup: 1000
-      # runAsNonRoot: true
-      # runAsUser: 100
 
   ############################################################
   # Container Information
@@ -547,16 +549,16 @@ pingdirectory:
   services:
     ldap:
       servicePort: 389
-      containerPort: 389
+      containerPort: 1389
       dataService: true
     ldaps:
       servicePort: 636
-      containerPort: 636
+      containerPort: 1636
       dataService: true
       clusterService: true
     https:
       servicePort: 443
-      containerPort: 443
+      containerPort: 1443
       ingressPort: 443
       dataService: true
 
@@ -654,11 +656,11 @@ pingdatasync:
   services:
     ldaps:
       servicePort: 636
-      containerPort: 636
+      containerPort: 1636
       clusterService: true
     https:
       servicePort: 443
-      containerPort: 443
+      containerPort: 1443
       dataService: true
 
 #############################################################
@@ -686,12 +688,12 @@ pingdatagovernance:
   services:
     https:
       servicePort: 443
-      containerPort: 443
+      containerPort: 1443
       ingressPort: 443
       dataService: true
     ldaps:
       servicePort: 636
-      containerPort: 636
+      containerPort: 1636
       clusterService: true
 
   ingress:

--- a/docs/config/private-cert.md
+++ b/docs/config/private-cert.md
@@ -38,8 +38,8 @@ global:
 
 Generating an internal certificate is as simple setting the `privateCert.generate` to `true`.
 
-
 !!! note "Example of generating an internal certificate for pingaccess-engine"
+
 ```yaml
 pingaccess-admin:
   privateCert:

--- a/docs/config/vault.md
+++ b/docs/config/vault.md
@@ -41,13 +41,14 @@ container as it's json representation with all the secret key names/values.
 If dropped into the `SECRETS_DIR` (defaults to `/run/secrets`) directory, these files will
 be processed as:
 
-  * PROPERTY_FILE if the file ends in `.env` or
-  * Multiple files will be created for each key=value pair.
+* PROPERTY_FILE if the file ends in `.env` or
+* Multiple files will be created for each key=value pair.
 
 See the example below in this document for the
 transformation that occurs with the `devops-secret.env`.
 
 ## Vault Annotations
+
 Default yaml defined in the global vault section.  The options of annotation names/values
 can be found at
 [vault definitions](https://www.vaultproject.io/docs/platform/k8s/injector/annotations)
@@ -78,6 +79,7 @@ make use of the secrets and an example of where secrets will be placed into cont
 
 !!! note "Example: Hashicorp Vault secrets"
     SECRET:secrets/jsmith@example.com/jsmith-namespace/licenses
+
     ```
     {
       "pingaccess-6.2": "Product=PingAccess\nVersion=6.2...",
@@ -102,7 +104,6 @@ make use of the secrets and an example of where secrets will be placed into cont
       "tls.key": "LS0tLS1CRUdJ...38sj"
     }
     ```
-
 
 !!! note "Example: Vault secrets .yaml"
     ```yaml

--- a/docs/config/workload.md
+++ b/docs/config/workload.md
@@ -39,6 +39,8 @@ global:
                 requests:
                   storage: 4Gi
 
+    securityContext:
+      fsGroup: 9999
     securityContext: {}
 ```
 
@@ -50,6 +52,7 @@ global:
 | statefulSet.partition             | Used for canary testing if n>0                                                               |
 | statefulSet.persistentVolume      | Provides details around creation of PVC/Volumes (see below)                                  |
 | securityContext                   | Provides security context details for starting container as different user/group (see below) |
+| securityContext.fsGroup           | Sets the group id on fileSystem writes.  This is needed especially for mounted volumes (pvs) |
 
 !!! note "Persistent Volumes"
     For every volume defined in the volumes list, 3 items will be
@@ -70,9 +73,9 @@ global:
       workload:
         container:
           securityContext:
-            runAsGroup: 1000
-            runAsUser: 3000
-            fsGroup: 2000
+            runAsGroup: 9999
+            runAsUser: 9031
+            fsGroup: 9999
     ```
 
 !!! note "WaitFor"

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,19 @@
 # Release Notes
 
+## Release 0.5.3
 
+* [Issue #121](https://github.com/pingidentity/helm-charts/issues/121) - Create global-env-vars hosts/ports
+  for all products regardless if enabled
+
+    The status of this config map is used to form the checksum for the products. This will ensure that a simple
+    addition/deletion of a product from the deployed mix won't cause all products to be restarted.
+
+* [Issue #122](https://github.com/pingidentity/helm-charts/issues/122) - Update image.tag to 2103 (March 2021)
+
+    The image tag is modified to 2103. This includes:
+
+    * Security Context on StatefulSets to include a fsGroup=9999 (same as gid)
+    * Update the services ContainerPort to unprivileged ports (i..e. 636 --> 1636)
 
 ## Release 0.5.2
 


### PR DESCRIPTION
* [Issue #121](https://github.com/pingidentity/helm-charts/issues/121) - Create global-env-vars hosts/ports
  for all products regardless if enabled

    The status of this config map is used to form the checksum for the products. This will ensure that a simple
    addition/deletion of a product from the deployed mix won't cause all products to be restarted.

* [Issue #122](https://github.com/pingidentity/helm-charts/issues/122) - Update image.tag to 2103 (March 2021)

    The image tag is modified to 2103. This includes:

    * Security Context on StatefulSets to include a fsGroup=9999 (same as gid)
    * Update the services ContainerPort to unprivileged ports (i..e. 636 --> 1636)
