### PR TITLE
Release 0.5.4

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,9 +4,9 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.5.3 - Refer to http://helm.pingidentity.com/release-notes/#release-053
+# 0.5.4 - Refer to http://helm.pingidentity.com/release-notes/#release-054
 ########################################################################
-version: 0.5.3
+version: 0.5.4
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/

--- a/charts/ping-devops/templates/pinglib/_workload.tpl
+++ b/charts/ping-devops/templates/pinglib/_workload.tpl
@@ -157,7 +157,6 @@ spec:
       securityContext: {{ toYaml $v.workload.securityContext | nindent 8 }}
 
       {{/*--------------------- Volumes ------------------*/}}
-      {{- if or (and (eq $v.workload.type "StatefulSet") $v.workload.statefulSet.persistentvolume.enabled) $v.privateCert.generate }}
       volumes:
       {{- if and (eq $v.workload.type "StatefulSet") $v.workload.statefulSet.persistentvolume.enabled }}
       {{- range $volName, $val := $v.workload.statefulSet.persistentvolume.volumes }}
@@ -167,13 +166,11 @@ spec:
       {{- end }}
       {{- end }}
       {{- if $v.privateCert.generate }}
-      volumes:
       - name: private-keystore
         emptyDir: {}
       - name: private-cert
         secret:
           secretName: {{ include "pinglib.fullname" . }}-private-cert
-      {{- end }}
       {{- end }}
       {{- include "pinglib.workload.volumes" $v | nindent 6 }}
 
@@ -293,7 +290,6 @@ securityContext:
 {{ range tuple "secretVolumes" "configMapVolumes" }}
 {{ $volType := . }}
 {{- range $volName, $volVal := (index $v .) }}
-volumes:
 - name: {{ $volName }}
   {{- if eq $volType "secretVolumes" }}
   secret:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+
+## Release 0.5.4
+
+* [Issue #126](https://github.com/pingidentity/helm-charts/issues/126) - Unable to mount secretVolume and configMapVolumes simultaneously
+
+    Due to the fact that volumes: is an array of items volumes: usage with secret or configMap volumes exosed
+    the issue that multiple volumes: entries were used, and only kept the last one.  Fix included only using
+    volumes: once.  Note that the template will end up with a `volumes: null` if none are
+    set (i.e. deployment with no Secret/ConfigMap volumes), but that is ok.
+
 ## Release 0.5.3
 
 * [Issue #121](https://github.com/pingidentity/helm-charts/issues/121) - Create global-env-vars hosts/ports


### PR DESCRIPTION
* [Issue #126](https://github.com/pingidentity/helm-charts/issues/126) - Unable to mount secretVolume and configMapVolumes simultaneously

    Due to the fact that volumes: is an array of items volumes: usage with secret or configMap volumes exosed
    the issue that multiple volumes: entries were used, and only kept the last one.  Fix included only using
    volumes: once.  Note that the template will end up with a `volumes: null` if none are
    set (i.e. deployment with no Secret/ConfigMap volumes), but that is ok.