### PR TITLE
Release 0.5.5

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,9 +4,9 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.5.4 - Refer to http://helm.pingidentity.com/release-notes/#release-054
+# 0.5.5 - Refer to http://helm.pingidentity.com/release-notes/#release-055
 ########################################################################
-version: 0.5.4
+version: 0.5.5
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/

--- a/charts/ping-devops/templates/pinglib/_workload.tpl
+++ b/charts/ping-devops/templates/pinglib/_workload.tpl
@@ -132,7 +132,8 @@ spec:
 
         {{/*--------------------- Resources ------------------*/}}
         resources: {{ toYaml $v.container.resources | nindent 10 }}
-        {{- if or (and (eq $v.workload.type "StatefulSet") $v.workload.statefulSet.persistentvolume.enabled) $v.privateCert.generate }}
+
+        {{/*------------------- Volume Mounts ----------------*/}}
         volumeMounts:
         {{- if and (eq $v.workload.type "StatefulSet") $v.workload.statefulSet.persistentvolume.enabled }}
         {{- range $volName, $val := $v.workload.statefulSet.persistentvolume.volumes }}
@@ -144,7 +145,6 @@ spec:
         - name: private-keystore
           mountPath: /run/secrets/private-keystore
           readOnly: true
-        {{- end }}
         {{- end }}
         {{- include "pinglib.workload.volumeMounts" $v | nindent 8 }}
 
@@ -313,7 +313,6 @@ securityContext:
 {{ $volType := . }}
 {{- range $volName, $volVal := (index $v .) }}
 {{- range $keyName, $keyVal := $volVal.items }}
-volumeMounts:
 - name: {{ $volName }}
   mountPath: {{ $keyVal }}
   subPath: {{ base $keyVal }}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,13 @@
 # Release Notes
 
 
+## Release 0.5.5
+
+* [Issue #126](https://github.com/pingidentity/helm-charts/issues/126) - Unable to mount secretVolume and configMapVolumes simultaneously
+
+    This is one additional fix to the the same thing fixed in 0.5.4.  `volumeMounts:` had the same issue as `volumes:`.  This
+    completes and resolves issue #126.
+
 ## Release 0.5.4
 
 * [Issue #126](https://github.com/pingidentity/helm-charts/issues/126) - Unable to mount secretVolume and configMapVolumes simultaneously


### PR DESCRIPTION

* [Issue #126](https://github.com/pingidentity/helm-charts/issues/126) - Unable to mount secretVolume and configMapVolumes simultaneously

    This is one additional fix to the the same thing fixed in 0.5.4.  `volumeMounts:` had the same issue as `volumes:`.  This
    completes and resolves issue #126.