### PR TITLE
Release 0.5.6

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,9 +4,9 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.5.5 - Refer to http://helm.pingidentity.com/release-notes/#release-055
+# 0.5.6 - Refer to http://helm.pingidentity.com/release-notes/#release-056
 ########################################################################
-version: 0.5.5
+version: 0.5.6
 description: All Ping Identity product images with integration
 type: application
 home: https://devops.pingidentity.com/

--- a/charts/ping-devops/templates/NOTES.txt
+++ b/charts/ping-devops/templates/NOTES.txt
@@ -5,7 +5,7 @@
 #  {{ printf $format " " "---------------------" "-------" "---" "--" "----" "-" "----" "----" "-" "----" "---"}}
 #  {{ printf $format " " "global" (toString $.Values.global.image.tag) "" "" (toString $.Values.global.container.resources.requests.cpu) "/" (toString $.Values.global.container.resources.limits.cpu) (toString $.Values.global.container.resources.requests.memory) "/" (toString $.Values.global.container.resources.limits.memory) (ternary " √ " "" $.Values.global.ingress.enabled) }}
 #
-{{- $products := list "pingaccess-admin" "pingaccess-engine" "pingdataconsole" "pingdatagovernance" "pingdatagovernancepap" "pingdatasync" "pingdelegator" "pingdirectory" "pingfederate-admin" "pingfederate-engine" "---" "ldap-sdk-tools" "pd-replication-timing" }}
+{{- $products := list "pingaccess-admin" "pingaccess-engine" "pingdataconsole" "pingdatagovernance" "pingdatagovernancepap" "pingdatasync" "pingdelegator" "pingdirectory" "pingdirectoryproxy" "pingfederate-admin" "pingfederate-engine" "---" "ldap-sdk-tools" "pd-replication-timing" }}
 {{- range $prodName := $products }}
 {{- if eq $prodName "---" }}
 #

--- a/charts/ping-devops/templates/global/secret-cert.yaml
+++ b/charts/ping-devops/templates/global/secret-cert.yaml
@@ -1,4 +1,4 @@
-{{- range (list "pingaccess-admin" "pingaccess-engine" "pingdatagovernance" "pingdatasync" "pingdirectory" "pingfederate-admin" "pingfederate-engine" ) }}
+{{- range (list "pingaccess-admin" "pingaccess-engine" "pingdatagovernance" "pingdatasync" "pingdirectory" "pingdirectoryproxy" "pingfederate-admin" "pingfederate-engine" ) }}
     {{- if (merge (index $.Values . ) $.Values.global).privateCert.generate }}
         {{- include "pinglib.private-cert" (list $ .) }}
 ---
@@ -11,5 +11,6 @@
 {{- define "pingdatagovernance.private-cert" -}}{{- end -}}
 {{- define "pingdatasync.private-cert" -}}{{- end -}}
 {{- define "pingdirectory.private-cert" -}}{{- end -}}
+{{- define "pingdirectoryproxy.private-cert" -}}{{- end -}}
 {{- define "pingfederate-admin.private-cert" -}}{{- end -}}
 {{- define "pingfederate-engine.private-cert" -}}{{- end -}}

--- a/charts/ping-devops/templates/pingdirectoryproxy/configmap.yaml
+++ b/charts/ping-devops/templates/pingdirectoryproxy/configmap.yaml
@@ -1,0 +1,6 @@
+{{- include "pinglib.configmap" (list . "pingdirectoryproxy") -}}
+
+
+{{- define "pingdirectoryproxy.configmap" -}}
+data:
+{{- end -}}

--- a/charts/ping-devops/templates/pingdirectoryproxy/service-cluster.yaml
+++ b/charts/ping-devops/templates/pingdirectoryproxy/service-cluster.yaml
@@ -1,0 +1,12 @@
+{{- include "pinglib.service-cluster" (list . "pingdirectoryproxy") -}}
+
+
+{{- define "pingdirectoryproxy.service-cluster" -}}
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  publishNotReadyAddresses: true
+  selector:
+    clusterIdentifier: {{ include "pinglib.addreleasename" (append . "pingdirectoryproxy") }}
+{{- end -}}

--- a/charts/ping-devops/templates/pingdirectoryproxy/service.yaml
+++ b/charts/ping-devops/templates/pingdirectoryproxy/service.yaml
@@ -1,0 +1,6 @@
+{{- include "pinglib.service" (list . "pingdirectoryproxy") -}}
+
+
+
+{{- define "pingdirectoryproxy.service" -}}
+{{- end -}}

--- a/charts/ping-devops/templates/pingdirectoryproxy/workload.yaml
+++ b/charts/ping-devops/templates/pingdirectoryproxy/workload.yaml
@@ -1,0 +1,11 @@
+{{- include "pinglib.workload" (list . "pingdirectoryproxy") -}}
+
+
+
+{{- define "pingdirectoryproxy.workload" -}}
+spec:
+  template:
+    metadata:
+      labels:
+        clusterIdentifier: {{ include "pinglib.addreleasename" (append . "pingdirectoryproxy") }}
+{{- end -}}

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -494,10 +494,10 @@ pingdirectory:
     name: pingdirectory
 
   container:
-    replicaCount: 2
+    replicaCount: 1
     resources:
       requests:
-        cpu: 0
+        cpu: 50m
         memory: 2Gi
       limits:
         cpu: 2
@@ -580,6 +580,39 @@ pingdirectory:
     readiness:
       periodSeconds: 30
       failureThreshold: 4
+
+
+#############################################################
+# pingdirectoryproxy values
+#############################################################
+pingdirectoryproxy:
+  enabled: false
+  name: pingdirectoryproxy
+  image:
+    name: pingdirectoryproxy
+
+  container:
+    resources:
+      requests:
+        cpu: 0
+        memory: .75Gi
+      limits:
+        cpu: 2
+        memory: 2Gi
+
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: baseline/pingdirectoryproxy
+
+  services:
+    ldaps:
+      servicePort: 636
+      containerPort: 1636
+      clusterService: true
+    https:
+      servicePort: 443
+      containerPort: 1443
+      dataService: true
 
 #############################################################
 # pingdelegator values

--- a/docs/examples/everything.yaml
+++ b/docs/examples/everything.yaml
@@ -34,6 +34,9 @@ pingdirectory:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
     SERVER_PROFILE_PATH: baseline/pingdirectory
 
+pingdirectoryproxy:
+  enabled: true
+
 pingfederate-admin:
   enabled: true
   container:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,20 @@
 # Release Notes
 
 
+
+## Release 0.5.5 (April 29, 2021)
+
+* [Issue #133](https://github.com/pingidentity/helm-charts/issues/133) - Change default pingdirectory values
+  (container.resources.requests.cpu=50m and container.replicaCount=1)
+
+    Setting the cpu request to 50m, will provide at last some reservation of CPU, so that if there are multiple nodes,
+    it will better even out the load.
+
+    Additionally, setting the replicaCount to 1 by default, as many cases in development, there isn't a great need to
+    have multiple replicas. If this is the case, simply set pingdirectory.container.replicaCount=2 or any number of replica's.
+
+* [Issue #132](https://github.com/pingidentity/helm-charts/issues/132) - Adding PingDirectoryProxy to mix of products
+
 ## Release 0.5.5
 
 * [Issue #126](https://github.com/pingidentity/helm-charts/issues/126) - Unable to mount secretVolume and configMapVolumes simultaneously


### PR DESCRIPTION
* Closes #133 - Change default pingdirectory values
  (container.resources.requests.cpu=50m and container.replicaCount=1)

    Setting the cpu request to 50m, will provide at last some reservation of CPU, so that if there are multiple nodes,
    it will better even out the load.

    Additionally, setting the replicaCount to 1 by default, as many cases in development, there isn't a great need to
    have multiple replicas. If this is the case, simply set pingdirectory.container.replicaCount=2 or any number of replica's.

* Closes #132  - Adding PingDirectoryProxy to mix of products