### PR TITLE
Release 0.5.7

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,10 +4,11 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.5.6 - Refer to http://helm.pingidentity.com/release-notes/#release-056
+# 0.5.7 - Refer to http://helm.pingidentity.com/release-notes/#release-057
 ########################################################################
-version: 0.5.6
+version: 0.5.7
 description: All Ping Identity product images with integration
 type: application
-home: https://devops.pingidentity.com/
-appVersion: "2103"
+home: https://helm.pingidentity.com/
+icon: https://helm.pingidentity.com/img/logos/ping.png
+appVersion: "2104"

--- a/charts/ping-devops/templates/pinglib/_service-cluster.tpl
+++ b/charts/ping-devops/templates/pinglib/_service-cluster.tpl
@@ -19,8 +19,10 @@ spec:
   {{- if ne $serviceName "clusterExternalDNSHostname" }}
   {{- if $val.clusterService }}
     - name: {{ $serviceName }}
-      port: {{ $val.servicePort }}
-      targetPort: {{ default $val.servicePort $val.containerPort }}
+      port: {{ required "containerPort is required for services with clusterService:true" $val.containerPort }}
+      # targetPort isn't provided as it will ALWAYS be the same as the
+      # port of the service,since it's a type:ClusterIP or headless
+      # service
       protocol: {{ default "TCP" $val.protocol }}
   {{- end }}
   {{- end }}

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -99,7 +99,7 @@ global:
   # By default the images uses will be indicated by these
   # variables.  An example might look like:
   #
-  #   pingidentity/pingdataconsole:2103 (March, 2021)
+  #   pingidentity/pingdataconsole:2104 (April, 2021)
   #
   # NOTE: image.name MUST be set in child chart
   #   Example: image.name: pingfederate
@@ -107,7 +107,7 @@ global:
   image:
     repository: pingidentity
     name:
-    tag: "2103"
+    tag: "2104"
     pullPolicy: Always
 
   ############################################################

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,17 @@
 # Release Notes
 
 
+## Release 0.5.7 (May 3, 2021)
+
+* [Issue #136](https://github.com/pingidentity/helm-charts/issues/136) ClusterIP Services
+  port/targetPort be set to the containerPort
+
+    Since the ClusterIP Services (aka Headless services) only provide access to the underlying container
+    IP and port.  The port, and by default targetPort, will be set to the containerPort value.  The helm
+    charts will start requiring the containerPort for any service where clusterService:true is set, otherwise
+    it will fail with an error message.
+
+* [Issue #138](https://github.com/pingidentity/helm-charts/issues/138) Update image.tag to 2104 (April 2021)
 
 ## Release 0.5.5 (April 29, 2021)
 


### PR DESCRIPTION
## Release 0.5.7 (May 3, 2021)

* [Issue #136](https://github.com/pingidentity/helm-charts/issues/136) ClusterIP Services
  port/targetPort be set to the containerPort

    Since the ClusterIP Services (aka Headless services) only provide access to the underlying container
    IP and port.  The port, and by default targetPort, will be set to the containerPort value.  The helm
    charts will start requiring the containerPort for any service where clusterService:true is set, otherwise
    it will fail with an error message.

* [Issue #138](https://github.com/pingidentity/helm-charts/issues/138) Update image.tag to 2104 (April 2021)

