### PR TITLE
Release 0.5.8

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,10 +4,10 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.5.7 - Refer to http://helm.pingidentity.com/release-notes/#release-057
+# 0.5.8 - Refer to http://helm.pingidentity.com/release-notes/#release-058
 ########################################################################
-version: 0.5.7
-description: All Ping Identity product images with integration
+version: 0.5.8
+description: Ping Identity product chart with integration
 type: application
 home: https://helm.pingidentity.com/
 icon: https://helm.pingidentity.com/img/logos/ping.png

--- a/charts/ping-devops/templates/pingfederate-engine/configmap.yaml
+++ b/charts/ping-devops/templates/pingfederate-engine/configmap.yaml
@@ -8,6 +8,6 @@ data:
   OPERATIONAL_MODE: CLUSTERED_ENGINE
   CLUSTER_BIND_ADDRESS: "NON_LOOPBACK"
   CLUSTER_NAME: {{ $top.Release.Name | quote }}
-  DNS_QUERY_LOCATION: "{{ include "pinglib.fullname" . }}-cluster.{{ $top.Release.Namespace }}.svc.cluster.local"
+  DNS_QUERY_LOCATION: "{{ include "pinglib.addreleasename" (list $top $v (index $top.Values "pingfederate-admin").name) }}-cluster.{{ $top.Release.Namespace }}.svc.cluster.local"
   DNS_RECORD_TYPE: "A"
 {{- end -}}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,6 +1,12 @@
 # Release Notes
 
 
+## Release 0.5.8 (May 6, 2021)
+
+* [Issue #141](https://github.com/pingidentity/helm-charts/issues/141) Fix DNS_QUERY_LOCATION on pingfederate-engine configmap.yaml
+
+    Resolves an issue with the DNS_QUERY_LOCATION when pingfederate clustering is used for >1 pingfederate-engines
+
 ## Release 0.5.7 (May 3, 2021)
 
 * [Issue #136](https://github.com/pingidentity/helm-charts/issues/136) ClusterIP Services


### PR DESCRIPTION

* [Issue #141](https://github.com/pingidentity/helm-charts/issues/141) Fix DNS_QUERY_LOCATION on pingfederate-engine configmap.yaml

    Resolves an issue with the DNS_QUERY_LOCATION when pingfederate clustering is used for >1 pingfederate-engines
