### PR TITLE
Release 0.6.1

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,9 +4,9 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.6.0 - Refer to http://helm.pingidentity.com/release-notes/#release-060
+# 0.6.1 - Refer to http://helm.pingidentity.com/release-notes/#release-061
 ########################################################################
-version: 0.6.0
+version: 0.6.1
 description: Ping Identity product chart with integration
 type: application
 home: https://helm.pingidentity.com/

--- a/charts/ping-devops/templates/pinglib/_workload.tpl
+++ b/charts/ping-devops/templates/pinglib/_workload.tpl
@@ -40,8 +40,8 @@ spec:
         {{ include "pinglib.selector.labels" . | nindent 8 }}
       annotations:
         {{ include "pinglib.annotations.vault" $v.vault | nindent 8 }}
-        {{ $prodChecksum := include (print $top.Template.BasePath "/" $v.name "/configmap.yaml") $top | sha256sum }}
-        {{ $globChecksum := include (print $top.Template.BasePath "/global/configmap.yaml") $top | sha256sum }}
+        {{ $prodChecksum := (include (print $top.Template.BasePath "/" $v.name "/configmap.yaml") $top | fromYaml).data | toYaml | sha256sum }}
+        {{ $globChecksum := (include (print $top.Template.BasePath "/global/configmap.yaml") $top | fromYaml).data | toYaml | sha256sum }}
         checksum/config: {{ print $prodChecksum $globChecksum | sha256sum }}
         {{- if $v.workload.annotations }}
         {{- toYaml $v.workload.annotations | nindent 8 }}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+
+## Release 0.6.1 (May 21, 2021)
+
+* [Issue #148](https://github.com/pingidentity/helm-charts/issues/148) Calculate checksum of ConfigMaps based
+  on the data rather than entire ConfigMap file
+
+    This will only use the ConfigMap.data when creating checksums in workload rather than using the
+    entire file.  It will result in no checksum change when labels/annotations are the only thing changing.
+    A good example is the helm chart version, which changes the label, but not data.
+
 ## Release 0.6.0 (May 11, 2021)
 
 * Changed default `global.image.pullPolicy` from `Always` to `IfNotPresent`.


### PR DESCRIPTION
## Release 0.6.1 (May 21, 2021)

* [Issue #148](https://github.com/pingidentity/helm-charts/issues/148) Calculate checksum of ConfigMaps based
  on the data rather than entire ConfigMap file

    This will only use the ConfigMap.data when creating checksums in workload rather than using the
    entire file.  It will result in no checksum change when labels/annotations are the only thing changing.
    A good example is the helm chart version, which changes the label, but not data.