### PR TITLE
Release 0.6.4

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,9 +4,9 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.6.3 - Refer to http://helm.pingidentity.com/release-notes/#release-063
+# 0.6.4 - Refer to http://helm.pingidentity.com/release-notes/#release-064
 ########################################################################
-version: 0.6.3
+version: 0.6.4
 description: Ping Identity product chart with integration
 type: application
 home: https://helm.pingidentity.com/

--- a/charts/ping-devops/templates/NOTES.txt
+++ b/charts/ping-devops/templates/NOTES.txt
@@ -1,5 +1,7 @@
 {{ include "pinglib.notes.header" . }}
 {{- $format := "%-1.1s %-21.21s %-7.7s %-3.3s %2.2s %4.4s%1s%-4.4s %4.4s%1s%-4.4s %3.3s" }}
+{{- $initconFormat := "    init    - %s" }}
+{{- $sidecarFormat := "    sidecar - %s" }}
 #
 #  {{ printf $format " " "       Product       " "  tag  " "typ" " #" " cpu" " " "R/L " " mem" " " "R/L " "Ing"}}
 #  {{ printf $format " " "---------------------" "-------" "---" "--" "----" "-" "----" "----" "-" "----" "---"}}
@@ -22,6 +24,14 @@
     {{- $meml := ternary (toString .container.resources.limits.memory) "" .enabled }}
     {{- $ingEnabled := .enabled | ternary (ternary " √ " "" .ingress.enabled) "" }}
 #  {{ printf $format $prodEnabled $prodName $tag $workload $numReplica $cpur $slash $cpul $memr $slash $meml $ingEnabled  }}
+{{- if .enabled }}
+{{- range .includeInitContainers }}
+#  {{ printf $initconFormat . }}
+{{- end }}
+{{- range .includeSidecars }}
+#  {{ printf $sidecarFormat . }}
+{{- end }}
+{{- end }}
 {{- end }}
 {{- end }}
 #

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -354,6 +354,57 @@ global:
     secret:
       devOps: devops-secret
 
+  #############################################################
+  # Includes for sidecars, initContainers and volumes
+  #
+  # At both global and product level, includes of sidecars,
+  # initContainers and volumes can be provided.  By default,
+  # none are included.
+  #############################################################
+  includeSidecars: []
+  includeInitContainers: []
+  includeVolumes: []
+
+#############################################################
+# Sidecar Definitions
+#
+# Available sidecar definitions available to product
+#############################################################
+sidecars: {}
+# Example:
+# sidecars:
+#   logger:
+#     name: log-container
+#     image: pingidentity/pingtoolkit:2105
+#     volumeMounts:
+#       - mountPath: /tmp/logs/
+#         name: logger
+#         readOnly: false
+
+#############################################################
+# InitContainer Definitions
+#
+# Available initContainer definitions available to product
+#############################################################
+initContainers: {}
+# Example:
+# initContainers:
+#   init-example:
+#     name: 01-init
+#     image: pingidentity/pingtoolkit:2105
+#     command: ['sh', '-c', 'echo "InitContainer 1"']
+
+#############################################################
+# Volume Definitions
+#
+# Available volume definitions available to be used within
+# sidecars, initContainers or main product containers
+#############################################################
+volumes: {}
+# Examples:
+# volumes:
+#   logger:
+#     emptyDir: {}
 
 #############################################################
 # Image/Product values


### PR DESCRIPTION

* [Issue #158](https://github.com/pingidentity/helm-charts/issues/158) Increment default tag to 2105
    Sidecars and initContainers are valuable for a multitude of reasons - log forwarding, metric exporting, backup jobs. Because of this they can also have many ways of being configured.

    Allow for defining three top level maps to provide details for:

    * sidecars - Defines sidecar containers to be run alongside product containers.
    * initContainers - Defines initContainers to be run before product containers.
    * volumes - Defines volumes used by sidecars, initContainers and product containers.

        ```
        sidecars:
          pd-access-logger:
            name: pd-access-log-container
            image: pingidentity/pingtoolkit:2105
            volumeMounts:
              - mountPath: /tmp/pd-access-logs/
                name: pd-access-logs
                readOnly: false
          statsd-exporter:
            name: statsd-exporter
            image: prom/statsd-exporter:v0.14.1
            args:
            - "--statsd.mapping-config=/tmp/mapping/statsd-mapping.yml"
            - "--statsd.listen-udp=:8125"
            - "--web.listen-address=:9102"
            ports:
              - containerPort: 9102
                protocol: TCP
              - containerPort: 8125
                protocol: UDP

        initContainers:
          init-1:
            name: 01-init
            image: pingidentity/pingtoolkit:2105
            command: ['sh', '-c', 'echo "Initing 1" && touch /tmp/pd-access-logs/init-1']
            volumeMounts:
              - mountPath: /tmp/pd-access-logs/
                name: pd-access-logs
                readOnly: false

        volumes:
          pd-access-logs:
            emptyDir: {}
          statsd-mapping:
            configMap:
              name: statsd-config
              items:
                - key: config
                  path: statsd-mapping.yml
        ```

    And within the product (or global) definition, allow for inclusion of sidecars, initContainers and volumes.  These must be available in the top-level `sidecars:`, `initContainers:` and `volumes:`

    * includeSidecars
    * includeInitContainers - Run in order as listed in array
    * includeVolumes

        ```
        pingdirectory:
          ...
          includeSidecars:
            - pd-access-logger
          includeInitContainers:
            - init-1
          includeVolumes:
            - pd-access-logs

          volumeMounts:
            - mountPath: /opt/access-logs/
              name: pd-access-logs
        ```