### PR TITLE
Release 0.6.5 - Addig PingAuthorize/PAP

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,9 +4,9 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.6.4 - Refer to http://helm.pingidentity.com/release-notes/#release-064
+# 0.6.5 - Refer to http://helm.pingidentity.com/release-notes/#release-065
 ########################################################################
-version: 0.6.4
+version: 0.6.5
 description: Ping Identity product chart with integration
 type: application
 home: https://helm.pingidentity.com/

--- a/charts/ping-devops/templates/NOTES.txt
+++ b/charts/ping-devops/templates/NOTES.txt
@@ -7,7 +7,7 @@
 #  {{ printf $format " " "---------------------" "-------" "---" "--" "----" "-" "----" "----" "-" "----" "---"}}
 #  {{ printf $format " " "global" (toString $.Values.global.image.tag) "" "" (toString $.Values.global.container.resources.requests.cpu) "/" (toString $.Values.global.container.resources.limits.cpu) (toString $.Values.global.container.resources.requests.memory) "/" (toString $.Values.global.container.resources.limits.memory) (ternary " √ " "" $.Values.global.ingress.enabled) }}
 #
-{{- $products := list "pingaccess-admin" "pingaccess-engine" "pingdataconsole" "pingdatagovernance" "pingdatagovernancepap" "pingdatasync" "pingdelegator" "pingdirectory" "pingdirectoryproxy" "pingfederate-admin" "pingfederate-engine" "---" "ldap-sdk-tools" "pd-replication-timing" }}
+{{- $products := list "pingaccess-admin" "pingaccess-engine" "pingauthorize" "pingauthorizepap" "pingdataconsole" "pingdatagovernance" "pingdatagovernancepap" "pingdatasync" "pingdelegator" "pingdirectory" "pingdirectoryproxy" "pingfederate-admin" "pingfederate-engine" "---" "ldap-sdk-tools" "pd-replication-timing" }}
 {{- range $prodName := $products }}
 {{- if eq $prodName "---" }}
 #

--- a/charts/ping-devops/templates/global/configmap.yaml
+++ b/charts/ping-devops/templates/global/configmap.yaml
@@ -3,9 +3,12 @@
 {{- define "global.configmap" -}}
 {{- $top := index . 0 -}}
 {{- $v := index . 1 -}}
+
 data:
   {{ include "global.private.host.port" (list $top $v "PA_ADMIN" "pingaccess-admin") }}
   {{ include "global.private.host.port" (list $top $v "PA_ENGINE" "pingaccess-engine") }}
+  {{ include "global.private.host.port" (list $top $v "PAZ_ENGINE" "pingauthorize") }}
+  {{ include "global.private.host.port" (list $top $v "PAZP_ENGINE" "pingauthorizepap") }}
   {{ include "global.private.host.port" (list $top $v "PD_CONSOLE" "pingdataconsole") }}
   {{ include "global.private.host.port" (list $top $v "PDS_ENGINE" "pingdatasync") }}
   {{ include "global.private.host.port" (list $top $v "PDG_ENGINE" "pingdatagovernance") }}
@@ -18,6 +21,8 @@ data:
 
   {{ include "global.public.host.port" (list $top $v "PA_ADMIN" "pingaccess-admin") }}
   {{ include "global.public.host.port" (list $top $v "PA_ENGINE" "pingaccess-engine") }}
+  {{ include "global.public.host.port" (list $top $v "PAZ_ENGINE" "pingauthorize") }}
+  {{ include "global.public.host.port" (list $top $v "PAZP_ENGINE" "pingauthorizepap") }}
   {{ include "global.public.host.port" (list $top $v "PD_CONSOLE" "pingdataconsole") }}
   {{ include "global.public.host.port" (list $top $v "PDS_ENGINE" "pingdatasync") }}
   {{ include "global.public.host.port" (list $top $v "PDG_ENGINE" "pingdatagovernance") }}

--- a/charts/ping-devops/templates/global/secret-cert.yaml
+++ b/charts/ping-devops/templates/global/secret-cert.yaml
@@ -1,4 +1,4 @@
-{{- range (list "pingaccess-admin" "pingaccess-engine" "pingdatagovernance" "pingdatasync" "pingdirectory" "pingdirectoryproxy" "pingfederate-admin" "pingfederate-engine" ) }}
+{{- range (list "pingaccess-admin" "pingaccess-engine" "pingauthorize" "pingdatagovernance" "pingdatasync" "pingdirectory" "pingdirectoryproxy" "pingfederate-admin" "pingfederate-engine" ) }}
     {{- if (merge (index $.Values . ) $.Values.global).privateCert.generate }}
         {{- include "pinglib.private-cert" (list $ .) }}
 ---
@@ -8,6 +8,7 @@
 
 {{- define "pingaccess-admin.private-cert" -}}{{- end -}}
 {{- define "pingaccess-engine.private-cert" -}}{{- end -}}
+{{- define "pingauthorize.private-cert" -}}{{- end -}}
 {{- define "pingdatagovernance.private-cert" -}}{{- end -}}
 {{- define "pingdatasync.private-cert" -}}{{- end -}}
 {{- define "pingdirectory.private-cert" -}}{{- end -}}

--- a/charts/ping-devops/templates/pingauthorize/configmap.yaml
+++ b/charts/ping-devops/templates/pingauthorize/configmap.yaml
@@ -1,0 +1,6 @@
+{{- include "pinglib.configmap" (list . "pingauthorize") -}}
+
+
+
+{{- define "pingauthorize.configmap" -}}
+{{- end -}}

--- a/charts/ping-devops/templates/pingauthorize/ingress.yaml
+++ b/charts/ping-devops/templates/pingauthorize/ingress.yaml
@@ -1,0 +1,8 @@
+{{- if (merge (index .Values "pingauthorize") .Values.global).ingress.enabled }}
+{{- include "pinglib.ingress" (list . "pingauthorize") -}}
+{{- end -}}
+
+
+
+{{- define "pingauthorize.ingress" -}}
+{{- end -}}

--- a/charts/ping-devops/templates/pingauthorize/service-cluster.yaml
+++ b/charts/ping-devops/templates/pingauthorize/service-cluster.yaml
@@ -1,0 +1,12 @@
+{{- include "pinglib.service-cluster" (list . "pingauthorize") -}}
+
+
+{{- define "pingauthorize.service-cluster" -}}
+metadata:
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  publishNotReadyAddresses: true
+  selector:
+    clusterIdentifier: {{ include "pinglib.addreleasename" (append . "pingauthorize") }}
+{{- end -}}

--- a/charts/ping-devops/templates/pingauthorize/service.yaml
+++ b/charts/ping-devops/templates/pingauthorize/service.yaml
@@ -1,0 +1,6 @@
+{{- include "pinglib.service" (list . "pingauthorize") -}}
+
+
+
+{{- define "pingauthorize.service" -}}
+{{- end -}}

--- a/charts/ping-devops/templates/pingauthorize/workload.yaml
+++ b/charts/ping-devops/templates/pingauthorize/workload.yaml
@@ -1,0 +1,11 @@
+{{- include "pinglib.workload" (list . "pingauthorize") -}}
+
+
+
+{{- define "pingauthorize.workload" -}}
+spec:
+  template:
+    metadata:
+      labels:
+        clusterIdentifier: {{ include "pinglib.addreleasename" (append . "pingauthorize") }}
+{{- end -}}

--- a/charts/ping-devops/templates/pingauthorizepap/configmap.yaml
+++ b/charts/ping-devops/templates/pingauthorizepap/configmap.yaml
@@ -1,0 +1,18 @@
+{{- include "pinglib.configmap" (list . "pingauthorizepap") -}}
+
+
+
+{{- define "pingauthorizepap.configmap" -}}
+{{- $top := index . 0 -}}
+{{- $v := index . 1 -}}
+data:
+  {{- if $v.ingress.enabled }}
+  PING_EXTERNAL_BASE_URL: {{ printf "%s:%s" (include "pinglib.ingress.hostname" (list $top $v (index $v.ingress.hosts 0).host)) (toString $v.services.https.ingressPort) }}
+  {{- else }}
+  PING_EXTERNAL_BASE_URL: localhost:8443
+  {{- end -}}
+{{- end -}}
+
+
+{{- define "pingauthorizepap.configmap" -}}
+{{- end -}}

--- a/charts/ping-devops/templates/pingauthorizepap/ingress.yaml
+++ b/charts/ping-devops/templates/pingauthorizepap/ingress.yaml
@@ -1,0 +1,8 @@
+{{- if (merge (index .Values "pingauthorizepap") .Values.global).ingress.enabled }}
+{{- include "pinglib.ingress" (list . "pingauthorizepap") -}}
+{{- end -}}
+
+
+
+{{- define "pingauthorizepap.ingress" -}}
+{{- end -}}

--- a/charts/ping-devops/templates/pingauthorizepap/service.yaml
+++ b/charts/ping-devops/templates/pingauthorizepap/service.yaml
@@ -1,0 +1,6 @@
+{{- include "pinglib.service" (list . "pingauthorizepap") -}}
+
+
+
+{{- define "pingauthorizepap.service" -}}
+{{- end -}}

--- a/charts/ping-devops/templates/pingauthorizepap/workload.yaml
+++ b/charts/ping-devops/templates/pingauthorizepap/workload.yaml
@@ -1,0 +1,6 @@
+{{- include "pinglib.workload" (list . "pingauthorizepap") -}}
+
+
+
+{{- define "pingauthorizepap.workload" -}}
+{{- end -}}

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -807,6 +807,96 @@ pingdatasync:
     clusterServiceName: pingdatasync-cluster
 
 #############################################################
+# pingauthorize values
+#############################################################
+pingauthorize:
+  enabled: false
+  name: pingauthorize
+  image:
+    name: pingauthorize
+
+  container:
+    resources:
+      requests:
+        cpu: 0
+        memory: 1.5Gi
+      limits:
+        cpu: 2
+        memory: 4Gi
+
+  envs:
+    SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: paz-pap-integration/pingauthorize
+    SERVER_PROFILE_PARENT: PAZ
+    SERVER_PROFILE_PAZ_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PAZ_PATH: baseline/pingauthorize
+
+  services:
+    https:
+      servicePort: 443
+      containerPort: 1443
+      ingressPort: 443
+      dataService: true
+    ldaps:
+      servicePort: 636
+      containerPort: 1636
+      clusterService: true
+    clusterServiceName: pingauthorize-cluster
+
+  ingress:
+    hosts:
+      - host: pingauthorize._defaultDomain_
+        paths:
+        - path: /
+          backend:
+            serviceName: https
+    tls:
+      - secretName: _defaultTlsSecret_
+        hosts:
+          - pingauthorize._defaultDomain_
+
+#############################################################
+# pingauthorizepap values
+#############################################################
+pingauthorizepap:
+  enabled: false
+  name: pingauthorizepap
+  image:
+    name: pingauthorizepap
+
+  container:
+    resources:
+      requests:
+        cpu: 0
+        memory: .75Gi
+      limits:
+        cpu: 2
+        memory: 2Gi
+
+  envs:
+    SERVER_PROFILE_URL: https://www.github.com/pingidentity/pingidentity-server-profiles.git
+    SERVER_PROFILE_PATH: paz-pap-integration/pingauthorizepap
+    HTTPS_PORT: "8443"
+  services:
+    https:
+      servicePort: 8443
+      containerPort: 8443
+      ingressPort: 443
+      dataService: true
+
+  ingress:
+    hosts:
+      - host: pingauthorizepap._defaultDomain_
+        paths:
+        - path: /
+          backend:
+            serviceName: https
+    tls:
+      - secretName: _defaultTlsSecret_
+        hosts:
+          - pingauthorizepap._defaultDomain_
+
+#############################################################
 # pingdatagovernance values
 #############################################################
 pingdatagovernance:

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## Release 0.6.5 (July 4, 2021)
+
+* [Issue #163](https://github.com/pingidentity/helm-charts/issues/163) Add PingAuthorize and
+    PingAuthorizePAP to helm charts.
+
+    !!! note "Includes pre-release to PingAuthorize 8.3"
+        This includes the necessary config for PingAuthorize and PingAuthorizePAP even though
+        there isn't a release for 2105.  The current edge release is required to use the default
+        server-profiles provided in the values.yaml.  Once the global tag is changed to 2106 (over next
+        few days) PingAuthorize will be default for use over PingDataGoverance.  This will be tracked in
+        a ticket released 2105.
+
 ## Release 0.6.4 (July 1, 2021)
 
 * [Issue #158](https://github.com/pingidentity/helm-charts/issues/158) Increment default tag to 2105


### PR DESCRIPTION
Add PingAuthorize and PingAuthorizePAP to helm charts.

This includes the necessary config for PingAuthorize and PingAuthorizePAP even though
        there isn't a release for 2105.  The current edge release is required to use the default
        server-profiles provided in the values.yaml.  Once the global tag is changed to 2106 (over next
        few days) PingAuthorize will be default for use over PingDataGoverance.  This will be tracked in
        a ticket released 2105.


        pingdataconsole:
          enabled: true

        pingdirectory:
          enabled: true

        pingauthorize:
          image:
            tag: 8.3.0.0-edge
          enabled: true

        pingauthorizepap:
          enabled: true