### PR TITLE
Release 0.6.6

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,11 +4,11 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.6.5 - Refer to http://helm.pingidentity.com/release-notes/#release-065
+# 0.6.6 - Refer to http://helm.pingidentity.com/release-notes/#release-066
 ########################################################################
-version: 0.6.5
+version: 0.6.6
 description: Ping Identity product chart with integration
 type: application
 home: https://helm.pingidentity.com/
 icon: https://helm.pingidentity.com/img/logos/ping.png
-appVersion: "2105"
+appVersion: "2106"

--- a/charts/ping-devops/templates/pinglib/_test_postman.tpl
+++ b/charts/ping-devops/templates/pinglib/_test_postman.tpl
@@ -36,6 +36,7 @@ spec:
     #--------------------- Command -----------------------
     command:
       {{ toYaml .command | nindent 6 }}
+    securityContext: {{ toYaml .securityContext | nindent 6 }}
   {{- end }}
     #--------------------- Environment -----------------
     envFrom:
@@ -67,6 +68,7 @@ spec:
     image: {{ default .image (index $v.externalImage .image) }}
     command:
       {{ toYaml .command | nindent 6 }}
+    securityContext: {{ toYaml .securityContext | nindent 6 }}
     volumeMounts:
     - name: shared-data
       mountPath: {{ $sharedMountPath }}
@@ -75,17 +77,9 @@ spec:
         cpu: 500m
         memory: 128Mi
       requests:
-        cpu: 250m
+        cpu: 0m
         memory: 64Mi
-    securityContext:
-      allowPrivilegeEscalation: false
-      capabilities:
-        drop:
-        - ALL
-      readOnlyRootFilesystem: true
-      runAsGroup: 1000
-      runAsNonRoot: true
-      runAsUser: 100
+  securityContext: {{ toYaml $testFramework.securityContext | nindent 4 }}
   {{- end }}
 
   #--------------------- VolumeMounts -----------------

--- a/charts/ping-devops/templates/tests/testFramework.yaml
+++ b/charts/ping-devops/templates/tests/testFramework.yaml
@@ -1,2 +1,3 @@
-
+{{- if .Values.testFramework.enabled }}
 {{ include "pinglib.test.job" (list $ $.Values.global $.Values.testFramework) }}
+{{- end -}}

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -113,7 +113,7 @@ global:
   # By default the images uses will be indicated by these
   # variables.  An example might look like:
   #
-  #   pingidentity/pingdataconsole:2105 (May, 2021)
+  #   pingidentity/pingdataconsole:2106 (June, 2021)
   #
   # NOTE: image.name MUST be set in child chart
   #   Example: image.name: pingfederate
@@ -121,7 +121,7 @@ global:
   image:
     repository: pingidentity
     name:
-    tag: "2105"
+    tag: "2106"
     pullPolicy: IfNotPresent
 
   ############################################################
@@ -132,7 +132,7 @@ global:
   ############################################################
   externalImage:
     # pingtoolkit - based on alpine
-    pingtoolkit: pingidentity/pingtoolkit:2105
+    pingtoolkit: pingidentity/pingtoolkit:2106
 
   ############################################################
   # Services
@@ -375,7 +375,7 @@ sidecars: {}
 # sidecars:
 #   logger:
 #     name: log-container
-#     image: pingidentity/pingtoolkit:2105
+#     image: pingidentity/pingtoolkit:2106
 #     volumeMounts:
 #       - mountPath: /tmp/logs/
 #         name: logger
@@ -391,7 +391,7 @@ initContainers: {}
 # initContainers:
 #   init-example:
 #     name: 01-init
-#     image: pingidentity/pingtoolkit:2105
+#     image: pingidentity/pingtoolkit:2106
 #     command: ['sh', '-c', 'echo "InitContainer 1"']
 
 #############################################################
@@ -1150,10 +1150,10 @@ pd-replication-timing:
 
 #############################################################
 # testFramework
-#
-# Beta
 #############################################################
 testFramework:
+  # Disabled by default
+  enabled: false
   name: testframework
   sharedMountPath: /var/run/shared
 
@@ -1198,9 +1198,16 @@ testFramework:
 
   finalStep:
     name: 99-completion
-    image: pingidentity/pingtoolkit:2105
+    image: busybox
     command:
       - /bin/sh
       - -c
       - echo "*************************************"; echo "Testing Complete"; date; echo "*************************************";
       - exit 0
+
+  #########################################################
+  # SecurityContext for all containers
+  #########################################################
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 2000

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,42 @@
 # Release Notes
 
+## Release 0.6.6 (July 7, 2021)
+
+* [Issue #160](https://github.com/pingidentity/helm-charts/issues/160) Change default image tag to 2106
+* [Issue #166](https://github.com/pingidentity/helm-charts/issues/166) Add securityContexts to testFramework containers
+    * Adding ability to provide a securityContext at the following levels:
+    * Changing the default finalStep image to busybox
+
+        ```
+        testFramework:
+          ...
+          #########################################################
+          # SecurityContext for all containers
+          #########################################################
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 2000
+            ...
+            testSteps:
+            - name: 01-init-example
+              ...
+              securityContext:
+                runAsUser: ...
+            ...
+            finalStep:
+              securityContext:
+                runAsUser: ...
+        ```
+
+* [Issue #167](https://github.com/pingidentity/helm-charts/issues/167) Disable testFramework by default
+    To enable, simply:
+
+    ```yaml
+    testFramework:
+      enabled: true
+      ...
+    ```
+
 ## Release 0.6.5 (July 4, 2021)
 
 * [Issue #163](https://github.com/pingidentity/helm-charts/issues/163) Add PingAuthorize and


### PR DESCRIPTION

* [Issue #160](https://github.com/pingidentity/helm-charts/issues/160) Change default image tag to 2106
* [Issue #166](https://github.com/pingidentity/helm-charts/issues/166) Add securityContexts to testFramework containers
    * Adding ability to provide a securityContext at the following levels:
    * Changing the default finalStep image to busybox

        ```yaml
        testFramework:
          ...
          #########################################################
          # SecurityContext for all containers
          #########################################################
          securityContext:
            runAsUser: 1000
            runAsGroup: 2000
            ...
            testSteps:
            - name: 01-init-example
              ...
              securityContext:
                runAsUser: ...
            ...
            finalStep:
              securityContext:
                runAsUser: ...
        ```

* [Issue #167](https://github.com/pingidentity/helm-charts/issues/167) Disable testFramework by default
    To enable, simply:

    ```yaml
    testFramework:
      enabled: true
      ...
    ```