### PR TITLE
Release 0.6.8

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,10 +4,10 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.6.7 - Refer to http://helm.pingidentity.com/release-notes/#release-067
+# 0.6.8 - Refer to http://helm.pingidentity.com/release-notes/#release-068
 ########################################################################
-version: 0.6.7
-description: Ping Identity helm charts - 07/28/21
+version: 0.6.8
+description: Ping Identity helm charts - 07/29/21
 type: application
 home: https://helm.pingidentity.com/
 icon: https://helm.pingidentity.com/img/logos/ping.png

--- a/charts/ping-devops/templates/pinglib/_ingress.tpl
+++ b/charts/ping-devops/templates/pinglib/_ingress.tpl
@@ -34,8 +34,15 @@ spec:
         {{- range .paths }}
           - path: {{ .path }}
             backend:
+{{- if semverCompare ">1.18" $top.Capabilities.KubeVersion.Version }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ (index $v.services .backend.serviceName).servicePort }}
+{{- else }}
               serviceName: {{ $fullName }}
               servicePort: {{ (index $v.services .backend.serviceName).servicePort }}
+{{- end }}
         {{- end }}
   {{- end }}
 {{- end -}}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,30 @@
 # Release Notes
 
+## Release 0.6.8 (July 29, 2021)
+
+* [Issue #175](https://github.com/pingidentity/helm-charts/issues/175) Invalid ingress resources on Kubernetes clusters > 1.18
+
+    During resoluton of issue #170 providing support for ingress apiVersion v1,
+    the necessary ingress yaml fields wearn't updated to relfect that new version.
+    This is a fix.  The backend definition of the Ingress will now reflect the proper
+    definition based on a v1 or v1beta1 apiVersion.
+
+    !!! note "Example: If KubeVersion > 1.18"
+        ```
+              service:
+                name: https
+                port:
+                  number: 443
+        ```
+
+    !!! note "Example: If KubeVersion <= 1.18"
+        ```
+              serviceName: https
+              servicePort: 443
+
+        ```
+
+
 ## Release 0.6.7 (July 28, 2021)
 
 * [Issue #170](https://github.com/pingidentity/helm-charts/issues/170) Update Ingress resource kind


### PR DESCRIPTION
* [Issue #175](https://github.com/pingidentity/helm-charts/issues/175) Invalid ingress resources on Kubernetes clusters > 1.18

    During resoluton of issue #170 providing support for ingress apiVersion v1,
    the necessary ingress yaml fields wearn't updated to relfect that new version.
    This is a fix.  The backend definition of the Ingress will now reflect the proper
    definition based on a v1 or v1beta1 apiVersion.

    Example: If KubeVersion > 1.18"
    ```
              service:
                name: https
                port:
                  number: 443
    ```

    Example: If KubeVersion <= 1.18"
    ```
              serviceName: https
              servicePort: 443

    ```