### PR TITLE
Release 0.7.1

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,10 +4,10 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.7.0 - Refer to http://helm.pingidentity.com/release-notes/#release-070
+# 0.7.1 - Refer to http://helm.pingidentity.com/release-notes/#release-071
 ########################################################################
-version: 0.7.0
-description: Ping Identity helm charts - 08/09/21
+version: 0.7.1
+description: Ping Identity helm charts - 08/13/21
 type: application
 home: https://helm.pingidentity.com/
 icon: https://helm.pingidentity.com/img/logos/ping.png

--- a/charts/ping-devops/templates/pingfederate-admin/configmap.yaml
+++ b/charts/ping-devops/templates/pingfederate-admin/configmap.yaml
@@ -6,8 +6,5 @@
 {{- $v := index . 1 -}}
 data:
   OPERATIONAL_MODE: CLUSTERED_CONSOLE
-  CLUSTER_BIND_ADDRESS: "NON_LOOPBACK"
-  CLUSTER_NAME: {{ $top.Release.Name | quote }}
-  DNS_QUERY_LOCATION: "{{ include "pinglib.fullclusterservicename" . }}.{{ $top.Release.Namespace }}.svc.cluster.local"
-  DNS_RECORD_TYPE: "A"
+{{ include "pinglib.configmap.pingfederate" . }}
 {{- end -}}

--- a/charts/ping-devops/templates/pingfederate-engine/configmap.yaml
+++ b/charts/ping-devops/templates/pingfederate-engine/configmap.yaml
@@ -6,8 +6,5 @@
 {{- $v := index . 1 -}}
 data:
   OPERATIONAL_MODE: CLUSTERED_ENGINE
-  CLUSTER_BIND_ADDRESS: "NON_LOOPBACK"
-  CLUSTER_NAME: {{ $top.Release.Name | quote }}
-  DNS_QUERY_LOCATION: "{{ include "pinglib.fullclusterservicename" . }}.{{ $top.Release.Namespace }}.svc.cluster.local"
-  DNS_RECORD_TYPE: "A"
+{{ include "pinglib.configmap.pingfederate" . }}
 {{- end -}}

--- a/charts/ping-devops/templates/pinglib/_configmap.tpl
+++ b/charts/ping-devops/templates/pinglib/_configmap.tpl
@@ -56,7 +56,7 @@ data:
 {{- $prodName := index . 3 }}
 {{- $services := (index $top.Values $prodName).services }}
 {{- with (index $top.Values $prodName) }}
-  {{- if and .ingress }}
+  {{- if .ingress }}
     {{- if .ingress.enabled }}
       {{- range .ingress.hosts }}
   {{ $envPrefix }}_PUBLIC_HOSTNAME: {{ include "pinglib.ingress.hostname" (list $top $v .host) | quote }}

--- a/charts/ping-devops/templates/pinglib/_configmap.tpl
+++ b/charts/ping-devops/templates/pinglib/_configmap.tpl
@@ -54,10 +54,10 @@ data:
 {{- $v := index . 1 }}
 {{- $envPrefix := index . 2 }}
 {{- $prodName := index . 3 }}
+{{- $services := (index $top.Values $prodName).services }}
 {{- with (index $top.Values $prodName) }}
-  {{- if .ingress }}
+  {{- if and .ingress }}
     {{- if .ingress.enabled }}
-      {{- $services := (index $top.Values $prodName).services }}
       {{- range .ingress.hosts }}
   {{ $envPrefix }}_PUBLIC_HOSTNAME: {{ include "pinglib.ingress.hostname" (list $top $v .host) | quote }}
 
@@ -66,7 +66,61 @@ data:
         {{- end }}
 
       {{- end }}
+    {{- else }}
+      {{- range .ingress.hosts }}
+  {{ $envPrefix }}_PUBLIC_HOSTNAME: localhost
+
+        {{- range .paths }}
+  {{ $envPrefix }}_PUBLIC_PORT_{{ .backend.serviceName | replace "-" "_" | upper }}: {{ (index $services .backend.serviceName).containerPort | quote }}
+        {{- end }}
+
+      {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}
+{{- end -}}
+
+{{/**********************************************************************
+   ** pinglib.configmap.pingfederate
+   **
+   ** provide default pingfederate configmap items (same for admin and engine)
+
+
+  ingress:
+    hosts:
+      - host: pingfederate-admin._defaultDomain_
+        paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            serviceName: https
+
+   **********************************************************************/}}
+{{- define "pinglib.configmap.pingfederate" -}}
+{{- $top := index . 0 }}
+{{- $v := index . 1 }}
+{{- $pingfedAdmin := index $top.Values "pingfederate-admin" }}
+{{- $httpsService := $pingfedAdmin.services.https }}
+  CLUSTER_BIND_ADDRESS: "NON_LOOPBACK"
+  CLUSTER_NAME: {{ $top.Release.Name | quote }}
+  DNS_QUERY_LOCATION: "{{ include "pinglib.fullclusterservicename" . }}.{{ $top.Release.Namespace }}.svc.cluster.local"
+  DNS_RECORD_TYPE: "A"
+  {{- if $pingfedAdmin.ingress.enabled }}
+    {{- range $pingfedAdmin.ingress.hosts }}
+      {{ $ingressHost := include "pinglib.ingress.hostname" (list $top $v .host) }}
+      {{- $ingressPort := $httpsService.ingressPort | int }}
+      {{- if eq $ingressPort 443 }}
+  PF_ADMIN_BASEURL: {{ printf "https://%s" $ingressHost }}
+      {{- else }}
+  PF_ADMIN_BASEURL: {{ printf "https://%s:%d" $ingressHost $ingressPort }}
+      {{- end }}
+    {{- end }}
+  {{- else }}
+    {{- $containerPort := $httpsService.containerPort | int }}
+    {{- if eq $containerPort 443 }}
+  PF_ADMIN_BASEURL: "https://localhost"
+    {{- else }}
+  PF_ADMIN_BASEURL: {{ printf "https://localhost:%d" $containerPort }}
+    {{- end }}
+  {{- end }}
 {{- end -}}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,33 @@
 # Release Notes
 
+## Release 0.7.1 (August 13, 2021)
+
+* [Issue #187](https://github.com/pingidentity/helm-charts/issues/187) Create the PUBLIC hostname/ports in the global env vars configmap all the time
+
+    Currently, the PUBLIC hostname/ports in the global env vars configmap are created if and only if the ingress in enabled.
+
+    Normally, this would be fine, except that some of the products (i.e PingFederate) use the PUBLIC environment variable to setup items like BASE URLs and redirects for the browser.  This is required for use cases when there is no ingress, but the user creates a port forward, as well as testing with no ingresses.
+
+    So, if no ingress is created, then the PUBLIC_HOSTNAMES should be set to `localhost` and the PUBLIC_PORT_* should be set to the same port as the contianerPort.
+
+    If ingress is used, then the functionality will not be changed, and the public hostname will be constructed as well as the public ingressPort.
+
+* [Issue #188](https://github.com/pingidentity/helm-charts/issues/188) Add the PF_ADMIN_BASEURL environment variable to the pingfederate admin/engine configmaps
+
+    With the 10.3 release of PingFederate, there is a variable used to provide redirect links called the PF_ADMIN_BASEURL.  This needs to be set by the helm chart, as it will either be a public host or localhost, depending on if the ingress is available.  The container has no idea which it should be as it doesn't have insight into the environment it's running.
+
+    If ingress is enabled, an example for this variable is:
+
+    ```
+    PF_ADMIN_BAESURL=https://pingfederate-admin.example.com
+    ```
+
+    If ingress is not enable, an example for this variable:
+
+    ```
+    PF_ADMIN_BASEURL=https://localhost:9999
+    ```
+
 ## Release 0.7.0 (August 09, 2021)
 
 * [Issue #184](https://github.com/pingidentity/helm-charts/issues/184) Create default ServiceAccount/Role/RoleBinding for testFramework


### PR DESCRIPTION
* [Issue #187](https://github.com/pingidentity/helm-charts/issues/187) Create the PUBLIC hostname/ports in the global env vars configmap all the time

    Currently, the PUBLIC hostname/ports in the global env vars configmap are created if and only if the ingress in enabled.

    Normally, this would be fine, except that some of the products (i.e PingFederate) use the PUBLIC environment variable to setup items like BASE URLs and redirects for the browser.  This is required for use cases when there is no ingress, but the user creates a port forward, as well as testing with no ingresses.

    So, if no ingress is created, then the PUBLIC_HOSTNAMES should be set to `localhost` and the PUBLIC_PORT_* should be set to the same port as the contianerPort.

    If ingress is used, then the functionality will not be changed, and the public hostname will be constructed as well as the public ingressPort.

* [Issue #188](https://github.com/pingidentity/helm-charts/issues/188) Add the PF_ADMIN_BASEURL environment variable to the pingfederate admin/engine configmaps

    With the 10.3 release of PingFederate, there is a variable used to provide redirect links called the PF_ADMIN_BASEURL.  This needs to be set by the helm chart, as it will either be a public host or localhost, depending on if the ingress is available.  The container has no idea which it should be as it doesn't have insight into the environment it's running.

    If ingress is enabled, an example for this variable is:

    ```
    PF_ADMIN_BAESURL=https://pingfederate-admin.example.com
    ```

    If ingress is not enable, an example for this variable:

    ```
    PF_ADMIN_BASEURL=https://localhost:9999
    ```
