### PR TITLE
Release 0.7.2

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,9 +4,9 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.7.1 - Refer to http://helm.pingidentity.com/release-notes/#release-071
+# 0.7.2 - Refer to http://helm.pingidentity.com/release-notes/#release-072
 ########################################################################
-version: 0.7.1
+version: 0.7.2
 description: Ping Identity helm charts - 08/13/21
 type: application
 home: https://helm.pingidentity.com/

--- a/charts/ping-devops/templates/pinglib/_configmap.tpl
+++ b/charts/ping-devops/templates/pinglib/_configmap.tpl
@@ -110,17 +110,17 @@ data:
       {{ $ingressHost := include "pinglib.ingress.hostname" (list $top $v .host) }}
       {{- $ingressPort := $httpsService.ingressPort | int }}
       {{- if eq $ingressPort 443 }}
-  PF_ADMIN_BASEURL: {{ printf "https://%s" $ingressHost }}
+  PF_ADMIN_PUBLIC_BASEURL: {{ printf "https://%s" $ingressHost }}
       {{- else }}
-  PF_ADMIN_BASEURL: {{ printf "https://%s:%d" $ingressHost $ingressPort }}
+  PF_ADMIN_PUBLIC_BASEURL: {{ printf "https://%s:%d" $ingressHost $ingressPort }}
       {{- end }}
     {{- end }}
   {{- else }}
     {{- $containerPort := $httpsService.containerPort | int }}
     {{- if eq $containerPort 443 }}
-  PF_ADMIN_BASEURL: "https://localhost"
+  PF_ADMIN_PUBLIC_BASEURL: "https://localhost"
     {{- else }}
-  PF_ADMIN_BASEURL: {{ printf "https://localhost:%d" $containerPort }}
+  PF_ADMIN_PUBLIC_BASEURL: {{ printf "https://localhost:%d" $containerPort }}
     {{- end }}
   {{- end }}
 {{- end -}}

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Release 0.7.2 (August 13, 2021)
+
+* [Issue #191](https://github.com/pingidentity/helm-charts/issues/191) Change variable PF_ADMIN_BASEURL to PF_ADMIN_PUBLIC_BASEURL
+
+    Release 0.7.2 created the new variable `PF_ADMIN_BASEURL`.  Due to the current user of the same variable with added `_PUBLIC_`,  the actual variable name needs to be `PF_ADMIN_PUBLIC_BASEURL`.
+
 ## Release 0.7.1 (August 13, 2021)
 
 * [Issue #187](https://github.com/pingidentity/helm-charts/issues/187) Create the PUBLIC hostname/ports in the global env vars configmap all the time


### PR DESCRIPTION
* [Issue #191](https://github.com/pingidentity/helm-charts/issues/191) Change variable PF_ADMIN_BASEURL to PF_ADMIN_PUBLIC_BASEURL

    Release 0.7.2 created the new variable `PF_ADMIN_BASEURL`.  Due to the current user of the same variable with added `_PUBLIC_`,  the actual variable name needs to be `PF_ADMIN_PUBLIC_BASEURL`.
