### PR TITLE
Release 0.7.3

### DIFF
--- a/charts/ping-devops/Chart.yaml
+++ b/charts/ping-devops/Chart.yaml
@@ -4,10 +4,10 @@
 apiVersion: v2
 name: ping-devops
 ########################################################################
-# 0.7.2 - Refer to http://helm.pingidentity.com/release-notes/#release-072
+# 0.7.3 - Refer to http://helm.pingidentity.com/release-notes/#release-073
 ########################################################################
-version: 0.7.2
-description: Ping Identity helm charts - 08/13/21
+version: 0.7.3
+description: Ping Identity helm charts - 08/24/21
 type: application
 home: https://helm.pingidentity.com/
 icon: https://helm.pingidentity.com/img/logos/ping.png

--- a/charts/ping-devops/templates/pinglib/_tests.tpl
+++ b/charts/ping-devops/templates/pinglib/_tests.tpl
@@ -21,23 +21,16 @@ spec:
   restartPolicy: Never
   initContainers:
 
+
   {{- range $testFramework.testSteps }}
-  {{- $stepName := .name }}
   {{- if .waitFor }}
-    {{ include "pinglib.workload.init.waitfor" (list $top $v .waitFor $stepName) | nindent 2 }}
+    {{ include "pinglib.workload.init.waitfor" (list $top $v .waitFor .name) | nindent 2 }}
   {{- else }}
-
-
-  - name: {{ $stepName }}
-    env: []
-    #--------------------- Image -------------------------
-    image: {{ default .image (index $v.externalImage .image) }}
+  - env: []
     imagePullPolicy: IfNotPresent
-    #--------------------- Command -----------------------
-    command:
-      {{ toYaml .command | nindent 6 }}
-    securityContext: {{ toYaml .securityContext | nindent 6 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
+
     #--------------------- Environment -----------------
     envFrom:
     - configMapRef:
@@ -64,27 +57,17 @@ spec:
     {{- end }}
   containers:
   {{- with $testFramework.finalStep }}
-  - name: {{ .name }}
-    image: {{ default .image (index $v.externalImage .image) }}
-    command:
-      {{ toYaml .command | nindent 6 }}
-    securityContext: {{ toYaml .securityContext | nindent 6 }}
+  - imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: shared-data
       mountPath: {{ $sharedMountPath }}
-    resources:
-      limits:
-        cpu: 500m
-        memory: 128Mi
-      requests:
-        cpu: 0m
-        memory: 64Mi
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- if $testFramework.rbac.enabled }}
   serviceAccountName: {{ include "pinglib.addreleasename" (list $top $v "test-service-account") }}
   {{- end }}
 
   {{ toYaml $testFramework.pod | nindent 2 }}
-  {{- end }}
 
   #--------------------- VolumeMounts -----------------
   # Setup a volume for each file in the configMaps.files

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -256,7 +256,7 @@ global:
     #       and group used with PingIdentity images (except PingDelegator).
     #       The fsGroup is set to same as group, however, it can be set to
     #       any gid number.
-    #       The fsGroup is required for any wordloads that volumeMount
+    #       The fsGroup is required for any workloads that volumeMount
     #       a pvc (i.e. StatefulSets)
     ############################################################
     securityContext:
@@ -491,7 +491,7 @@ pingfederate-admin:
   # configMapVolumes:
   #  pingfederate-props:
   #     items:
-  #      pf-props: /opt/in/etc/pingfederate.properties
+  #       pf-props: /opt/in/etc/pingfederate.properties
 
   services:
     https:
@@ -845,10 +845,7 @@ pingauthorize:
 
   envs:
     SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
-    SERVER_PROFILE_PATH: paz-pap-integration/pingauthorize
-    SERVER_PROFILE_PARENT: PAZ
-    SERVER_PROFILE_PAZ_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
-    SERVER_PROFILE_PAZ_PATH: baseline/pingauthorize
+    SERVER_PROFILE_PATH: getting-started/pingauthorize
 
   services:
     https:
@@ -894,9 +891,8 @@ pingauthorizepap:
         memory: 2Gi
 
   envs:
-    SERVER_PROFILE_URL: https://www.github.com/pingidentity/pingidentity-server-profiles.git
-    SERVER_PROFILE_PATH: paz-pap-integration/pingauthorizepap
     HTTPS_PORT: "8443"
+
   services:
     https:
       servicePort: 8443
@@ -1221,18 +1217,18 @@ testFramework:
     # Array of steps.
     # Example includes:
     #########################################################
-    # - name: 01-wait-for-pingfederate-engine
+    # 01-wait-for-pingfederate-engine:
     #   waitFor:
     #     pingfederate-engine:
     #       service: https
 
-    # - name: 02-init-test
+    # 02-init-test:
     #   image: busybox
     #   command:
     #     - /bin/sh
     #     - /var/run/init-test.sh
 
-    # - name: 03-check-pingfederate
+    # 03-check-pingfederate:
     #   image: postman/newman:5-alpine
     #   command:
     #     - newman
@@ -1246,11 +1242,19 @@ testFramework:
   finalStep:
     name: 99-completion
     image: busybox
+    imagePullPolicy: IfNotPresent
     command:
       - /bin/sh
       - -c
       - echo "*************************************"; echo "Testing Complete"; date; echo "*************************************";
       - exit 0
+    resources:
+      limits:
+        cpu: 500m
+        memory: 128Mi
+      requests:
+        cpu: 1m
+        memory: 64Mi
 
   #########################################################
   # Pod information to include

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -1217,18 +1217,18 @@ testFramework:
     # Array of steps.
     # Example includes:
     #########################################################
-    # 01-wait-for-pingfederate-engine:
+    # - name: 01-wait-for-pingfederate-engine
     #   waitFor:
     #     pingfederate-engine:
     #       service: https
 
-    # 02-init-test:
+    # - name: 02-init-test
     #   image: busybox
     #   command:
     #     - /bin/sh
     #     - /var/run/init-test.sh
 
-    # 03-check-pingfederate:
+    # - name: 03-check-pingfederate
     #   image: postman/newman:5-alpine
     #   command:
     #     - newman

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -1,5 +1,59 @@
 # Release Notes
 
+
+## Release 0.7.3 (August 24, 2021)
+
+* [Issue #194](https://github.com/pingidentity/helm-charts/issues/194) Change default envs for pingauthorize/pingauthorizepap
+
+    The current envs for pingauthroize in the values.yaml file are:
+
+    ```
+      envs:
+        SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+        SERVER_PROFILE_PATH: paz-pap-integration/pingauthorize
+        SERVER_PROFILE_PARENT: PAZ
+        SERVER_PROFILE_PAZ_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+        SERVER_PROFILE_PAZ_PATH: baseline/pingauthorize
+    ```
+
+    Just a side note here, the `baseline/pingauthorize` PATH includes a connection to pingdirectory, which will cause this to fail (pingauthorize https will return a 503).
+
+    If someone wants to override these, they need to be sure to uset/override the `SERVER_PROFILE_PARENT` variable, so the parent profiles aren't brought in.
+
+    The better default values.yaml should probably be:
+
+    ```
+      envs:
+        SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
+        SERVER_PROFILE_PATH: getting-started/pingauthorize
+    ```
+
+    For pingauthorizepap, it should have a default SERVER_PROFILE variables as empty, as no SERVER_PROFILE is needed by default.
+
+* [Issue #198](https://github.com/pingidentity/helm-charts/issues/198) testFramework: Support full definition of initContainers attributes in testSteps and finalStep
+
+    Update the testFramework to pull in all attributes of the testSteps and finalStep into the init containers and final container.  This allow for setting any resource, imagePullPolicy, ...
+
+    This came about as there was no way to set resource or imagePullPolicy details.
+
+    With this change, will be adding a couple of defaults into the value.yamls file for the finalStep:
+
+    ```
+      finalStep:
+        name: 99-completion
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command:
+          ...
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 1m
+            memory: 64Mi
+    ```
+
 ## Release 0.7.2 (August 13, 2021)
 
 * [Issue #191](https://github.com/pingidentity/helm-charts/issues/191) Change variable PF_ADMIN_BASEURL to PF_ADMIN_PUBLIC_BASEURL


### PR DESCRIPTION
* [Issue #194](https://github.com/pingidentity/helm-charts/issues/194) Change default envs for pingauthorize/pingauthorizepap

    The current envs for pingauthroize in the values.yaml file are:

    ```
      envs:
        SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
        SERVER_PROFILE_PATH: paz-pap-integration/pingauthorize
        SERVER_PROFILE_PARENT: PAZ
        SERVER_PROFILE_PAZ_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
        SERVER_PROFILE_PAZ_PATH: baseline/pingauthorize
    ```

    Just a side note here, the `baseline/pingauthorize` PATH includes a connection to pingdirectory, which will cause this to fail (pingauthorize https will return a 503).

    If someone wants to override these, they need to be sure to uset/override the `SERVER_PROFILE_PARENT` variable, so the parent profiles aren't brought in.

    The better default values.yaml should probably be:

    ```
      envs:
        SERVER_PROFILE_URL: https://github.com/pingidentity/pingidentity-server-profiles.git
        SERVER_PROFILE_PATH: getting-started/pingauthorize
    ```

    For pingauthorizepap, it should have a default SERVER_PROFILE variables as empty, as no SERVER_PROFILE is needed by default.

* [Issue #198](https://github.com/pingidentity/helm-charts/issues/198) testFramework: Support full definition of initContainers attributes in testSteps and finalStep

    Update the testFramework to pull in all attributes of the testSteps and finalStep into the init containers and final container.  This allow for setting any resource, imagePullPolicy, ...

    This came about as there was no way to set resource or imagePullPolicy details.

    With this change, will be adding a couple of defaults into the value.yamls file for the finalStep:

    ```
      finalStep:
        name: 99-completion
        image: busybox
        imagePullPolicy: IfNotPresent
        command:
          ...
        resources:
          limits:
            cpu: 500m
            memory: 128Mi
          requests:
            cpu: 1m
            memory: 64Mi
    ```

## Release 0.7.2 (August 13