### PR TITLE
add simple PingCentral

### DIFF
--- a/charts/ping-devops/templates/pingcentral/env-vars.yaml
+++ b/charts/ping-devops/templates/pingcentral/env-vars.yaml
@@ -1,0 +1,6 @@
+{{- include "pinglib.env-vars" (list . "pingcentral") -}}
+
+
+
+{{- define "pingcentral.env-vars" -}}
+{{- end -}}

--- a/charts/ping-devops/templates/pingcentral/ingress.yaml
+++ b/charts/ping-devops/templates/pingcentral/ingress.yaml
@@ -1,0 +1,8 @@
+{{- if (merge (index .Values "pingcentral") .Values.global).ingress.enabled }}
+{{- include "pinglib.ingress" (list . "pingcentral") -}}
+{{- end -}}
+
+
+
+{{- define "pingcentral.ingress" -}}
+{{- end -}}

--- a/charts/ping-devops/templates/pingcentral/service.yaml
+++ b/charts/ping-devops/templates/pingcentral/service.yaml
@@ -1,0 +1,6 @@
+{{- include "pinglib.service" (list . "pingcentral") -}}
+
+
+
+{{- define "pingcentral.service" -}}
+{{- end -}}

--- a/charts/ping-devops/templates/pingcentral/workload.yaml
+++ b/charts/ping-devops/templates/pingcentral/workload.yaml
@@ -1,0 +1,6 @@
+{{- include "pinglib.workload" (list . "pingcentral") -}}
+
+
+
+{{- define "pingcentral.workload" -}}
+{{- end -}}

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -1365,6 +1365,47 @@ pingaccess-engine:
           - pingaccess-engine._defaultDomain_
 
 #############################################################
+# @param    pingcentral PingCentral values
+#
+# @param    pingcentral.enabled Enable PingCentral deployment
+# @default  false
+#############################################################
+pingcentral:
+  enabled: false
+  name: pingcentral
+  image:
+    name: pingcentral
+
+  container:
+    resources:
+      requests:
+        cpu: 0
+        memory: .5Gi
+      limits:
+        cpu: 2
+        memory: 2Gi
+
+  services:
+    https:
+      containerPort: 9022
+      servicePort: 9022
+      ingressPort: 443
+      dataService: true
+
+  ingress:
+    hosts:
+      - host: pingcentral._defaultDomain_
+        paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            serviceName: https
+    tls:
+      - secretName: _defaultTlsSecret_
+        hosts:
+          - pingcentral._defaultDomain_
+
+#############################################################
 # @param    pingdataconsole PingDataConsole values
 #
 # @param    pingdataconsole.enabled Enable PingDataConsole deployment


### PR DESCRIPTION
[pingcentral.zip](https://github.com/pingidentity/helm-charts/files/7928595/pingcentral.zip)

In the attached zip this is examples for two ways PingCentral can be deployed:
- With H2 (internal db) - uncomment the OPTION 1 on values.yaml and install
- With External mysql:
  1. kubectl apply -f sample-mysql.yaml
  2. kubectl create secret generic pingcentral-jwk --from-file=pingcentral.jwk=pingcentral.jwk
  3. uncomment OPTION 2
  4. helm install rel pingidentity/ping-devops -f values.yaml