### PR TITLE
Add repository fully-qualified name

### DIFF
--- a/charts/ping-devops/templates/pinglib/_workload.tpl
+++ b/charts/ping-devops/templates/pinglib/_workload.tpl
@@ -70,7 +70,11 @@ spec:
 
         {{/*--------------------- Image -------------------------*/}}
         {{- with $v.image }}
-        image: "{{ .repository }}:{{ .tag }}"
+        {{- if $v.repositoryFqn }}
+        image: "{{ $v.repositoryFqn }}:{{ .tag }}"
+        {{- else }}
+        image: "{{ .repository }}/{{ .name }}:{{ .tag }}"
+        {{- end }}
         imagePullPolicy: {{ .pullPolicy }}
         {{- end }}
 
@@ -161,7 +165,11 @@ spec:
       {{- if $v.utilitySidecar.enabled }}
       - name: utility-sidecar
         {{- with $v.image }}
-        image: "{{ .repository }}:{{ .tag }}"
+        {{- if $v.repositoryFqn }}
+        image: "{{ $v.repositoryFqn }}:{{ .tag }}"
+        {{- else }}
+        image: "{{ .repository }}/{{ .name }}:{{ .tag }}"
+        {{- end }}
         imagePullPolicy: {{ .pullPolicy }}
         {{- end }}
         command: ["tail"]

--- a/charts/ping-devops/templates/pinglib/_workload.tpl
+++ b/charts/ping-devops/templates/pinglib/_workload.tpl
@@ -70,7 +70,7 @@ spec:
 
         {{/*--------------------- Image -------------------------*/}}
         {{- with $v.image }}
-        image: "{{ .repository }}/{{ .name }}:{{ .tag }}"
+        image: "{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy }}
         {{- end }}
 
@@ -161,7 +161,7 @@ spec:
       {{- if $v.utilitySidecar.enabled }}
       - name: utility-sidecar
         {{- with $v.image }}
-        image: "{{ .repository }}/{{ .name }}:{{ .tag }}"
+        image: "{{ .repository }}:{{ .tag }}"
         imagePullPolicy: {{ .pullPolicy }}
         {{- end }}
         command: ["tail"]

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -180,7 +180,7 @@ global:
   # @default  IfNotPresent
   ############################################################
   image:
-    registry: pingidentity
+    repository: pingidentity
     repositoryFqn:
     name:
     tag: "2201"

--- a/charts/ping-devops/values.yaml
+++ b/charts/ping-devops/values.yaml
@@ -159,11 +159,19 @@ global:
   #
   #   pingidentity/pingdataconsole:2201 (January, 2201)
   #
-  # NOTE: image.name MUST be set in child chart
-  #   Example: image.name: pingfederate
-  #
-  # @param    global.image.repository Default image repository
+  # @param    global.image.repository Default image registry
+  # @desc     is not the fully-qualified name of the image
+  # @desc     Example: image.repository: pingidentity, docker.io, 123.dkr.ecr.us-west-1.amazonaws.com
   # @default  pingidentity
+  #
+  # @param    global.image.repositoryFqn Repository fully-qualified name
+  # @desc     Overrides image.repository and image.name on the pod image spec
+  # @desc     MUST be set in child chart
+  # @desc     Example: image.repositoryFqn: pingidentity/pingfederate, docker.io/my-pingfederate
+  #
+  # @param    global.image.name Default image name
+  # @desc     MUST be set in child chart
+  # @desc     Example: image.name: pingfederate
   #
   # @param    global.image.tag Default image tag
   # @default  2201
@@ -172,7 +180,8 @@ global:
   # @default  IfNotPresent
   ############################################################
   image:
-    repository: pingidentity
+    registry: pingidentity
+    repositoryFqn:
     name:
     tag: "2201"
     pullPolicy: IfNotPresent


### PR DESCRIPTION
Hey Ping folk,

Hoping to add this change to allow us the ability to override this chart's default behaviour of splitting up the `container` image field with a fully-qualified image name.

This is a common pattern in Helm's `helm create` template chart:

`values.yaml`

```yaml
image:
  repository: nginx
  pullPolicy: IfNotPresent
  tag: ""
```

`templates/deployment.yaml`

```yaml
apiVersion: apps/v1
kind: Deployment
spec:
  template:
    spec:
      containers:
        - image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
```

Instead of changing two values fields, we can do it with just one.

This also enhances deployment tooling that requires the full-qualified image name like [Skaffold](https://skaffold.dev/docs/pipeline-stages/deployers/helm/#fqn-strategy-single-fully-qualified-name-default).

`skaffold.yaml`

```yaml
deploy:
  helm:
    releases:
      - name: my-ping
        chartPath: charts/ping-devops
        artifactOverrides:
          pingfederate-engine.repositoryFqn: gcr.io/my-ping/my-pingfederate
        imageStrategy:
          helm: {}
```

However, I'm mindful of introducing a *backwards-incompatible* change. So I've added a conditional `image.repositoryFqn` value that overrides `image.repository` & `image.name`.

The alternative *breaking* change would be `image.repository` being the full-qualified image name.

## Example

`values.yaml`

```yaml
pingfederate-engine:
  enabled: true
  repositoryFqn: docker.io/johnnyhuy/pingfederate
```

`ping-devops/templates/pingfederate-engine/workload.yaml`

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: ping-devops-pingfederate-engine
spec:
...
      image: docker.io/johnnyhuy/pingfederate:2201
...
```
