### PR TITLE
Don't Override the Deployments Replicas When Set With Autoscaling

### DIFF
--- a/charts/ping-devops/templates/pinglib/_workload.tpl
+++ b/charts/ping-devops/templates/pinglib/_workload.tpl
@@ -9,7 +9,9 @@ metadata:
   {{ include "pinglib.metadata.annotations" .  | nindent 2  }}
   name: {{ include "pinglib.fullname" . }}
 spec:
+  {{- if not $v.container.clustering.autoscaling.enabled }}
   replicas: {{ $v.container.replicaCount }}
+  {{- end }}
   selector:
     matchLabels: {{ include "pinglib.selector.labels" . | nindent 6 }}
 

--- a/charts/ping-devops/templates/pinglib/_workload.tpl
+++ b/charts/ping-devops/templates/pinglib/_workload.tpl
@@ -9,7 +9,7 @@ metadata:
   {{ include "pinglib.metadata.annotations" .  | nindent 2  }}
   name: {{ include "pinglib.fullname" . }}
 spec:
-  {{- if not $v.container.clustering.autoscaling.enabled }}
+  {{- if not $v.clustering.autoscaling.enabled }}
   replicas: {{ $v.container.replicaCount }}
   {{- end }}
   selector:

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 This is the documentation for using [Helm](https://helm.sh) to deploy the Ping Identity Docker Images.
 This single chart can be used to deploy any of the available Ping Identity products in a Kubernetes
-environment.
+environment. 
 
 ## DevOps Resources
 


### PR DESCRIPTION
When the replica count is set with autoscaling the replicas value should not be provided to the deployment template because during helm upgrade time the deployments replicas is reset to this number for the duration of the deployment essentially breaking the expected rolling update deployment strategy.

This pull request would resolve issue #276.

I know the contributing guidelines state that third party contributions are not accepted but this gives some context the changes mentioned in the issue and you can just take the change!