### PR TITLE
Support SemVer Pre-Release Comparisons for AWS EKS

### DIFF
--- a/charts/ping-devops/templates/pinglib/_cronjob.tpl
+++ b/charts/ping-devops/templates/pinglib/_cronjob.tpl
@@ -5,7 +5,7 @@
 {{- $podName := print $top.Release.Name "-" $v.name "-0" -}}
 {{- $baseArgs := list "exec" "-ti" $podName "--container" "utility-sidecar" "--" -}}
 {{- $args := concat $baseArgs $v.cronjob.args -}}
-{{- if semverCompare "<1.25" $top.Capabilities.KubeVersion.Version }}
+{{- if semverCompare "<1.25-0" $top.Capabilities.KubeVersion.Version }}
 apiVersion: batch/v1beta1
 {{- else }}
 apiVersion: batch/v1

--- a/charts/ping-devops/templates/pinglib/_hpa.tpl
+++ b/charts/ping-devops/templates/pinglib/_hpa.tpl
@@ -1,7 +1,7 @@
 {{- define "pinglib.hpa.tpl" -}}
 {{- $top := index . 0 -}}
 {{- $v := index . 1 -}}
-{{- if semverCompare ">1.22" $top.Capabilities.KubeVersion.Version }}
+{{- if semverCompare ">1.22-0" $top.Capabilities.KubeVersion.Version }}
 apiVersion: autoscaling/v2
 {{- else }}
 apiVersion: autoscaling/v2beta2

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 This is the documentation for using [Helm](https://helm.sh) to deploy the Ping Identity Docker Images.
 This single chart can be used to deploy any of the available Ping Identity products in a Kubernetes
-environment.
+environment. 
 
 ## DevOps Resources
 


### PR DESCRIPTION
AWS EKS always appends a pre-release specifier to the k8s version. Helm SemVer comparison ignores pre-releases unless the comparator specifies a pre-release.

This change would resolve issue #278.